### PR TITLE
JUnit failures counter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,21 @@ command:
     python -m mlx.warnings doc_log.txt --doxygen
 
 
+------------------------
+Parse for JUnit failures
+------------------------
+
+After you saved your JUnit XML output to the file, you can parse it with
+command:
+
+.. code-block:: bash
+
+    # command line
+    mlx-warnings junit_output.xml --junit
+    # explicitly as python module
+    python3 -m mlx.warnings junit_output.xml --junit
+    python -m mlx.warnings junit_output.xml --junit
+
 -------------
 Other options
 -------------

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -80,9 +80,9 @@ def main():
     for line in open(args.logfile, 'r'):
         if args.doxygen:
             warnings.check_doxygen_warnings(line)
-        elif args.sphinx:
+        if args.sphinx:
             warnings.check_sphinx_warnings(line)
-        elif args.junit:
+        if args.junit:
             warnings.check_junit_failures(line)
 
     warn_count = warnings.return_sphinx_warnings() + warnings.return_doxygen_warnings() + warnings.return_junit_failures()

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -12,6 +12,7 @@ sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 JUNIT_WARNING_REGEX = r"\<failure\s+message"
 junit_pattern = re.compile(JUNIT_WARNING_REGEX)
 
+
 class WarningsPlugin:
     def __init__(self):
         self.sphinx_counter = 0
@@ -52,6 +53,7 @@ class WarningsPlugin:
     def return_junit_failures(self):
         print("{count} junit failures found".format(count=self.junit_counter))
         return self.junit_counter
+
 
 def main():
     parser = argparse.ArgumentParser(prog='mlx-warnings')

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -8,7 +8,7 @@ doxy_pattern = re.compile(DOXYGEN_WARNING_REGEX)
 SPHINX_WARNING_REGEX = r"^(.+?:(?:\d+|None)): (DEBUG|INFO|WARNING|ERROR|SEVERE): (.+)\n?$"
 sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 
-JUNIT_WARNING_REGEX = r"\<failure\s+message"
+JUNIT_WARNING_REGEX = r"\<\s*failure\s+message"
 junit_pattern = re.compile(JUNIT_WARNING_REGEX)
 
 

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -15,6 +15,10 @@ class TestJUnitFailures(TestCase):
         self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name"><failure message="some random message from test case" /></testcase>')
         self.assertEqual(self.warnings.return_junit_failures(), 1)
 
+    def test_single_warning_with_random_spaces(self):
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name"> <   failure   message ="some random message from test case" /></testcase>')
+        self.assertEqual(self.warnings.return_junit_failures(), 1)
+
     def test_single_warning_mixed(self):
         self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name1" />')
         self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name2"><failure message="some random message from test case" /></testcase>')

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+
+from mlx.warnings import WarningsPlugin
+
+
+class TestJUnitFailures(TestCase):
+    def setUp(self):
+        self.warnings = WarningsPlugin()
+
+    def test_no_warning(self):
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name" />')
+        self.assertEqual(self.warnings.return_junit_failures(), 0)
+
+    def test_single_warning(self):
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name"><failure message="some random message from test case" /></testcase>')
+        self.assertEqual(self.warnings.return_junit_failures(), 1)
+
+    def test_single_warning_mixed(self):
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name1" />')
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name2"><failure message="some random message from test case" /></testcase>')
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name3" />')
+
+        self.assertEqual(self.warnings.return_junit_failures(), 1)
+
+    def test_dual_warning(self):
+        self.warnings.check_junit_failures('<testcase classname="dummy_class" name="dummy_name1"><failure message="some random message from test case 1" /></testcase><testcase classname="dummy_class" name="dummy_name2"><failure message="some random message from test case 2" /></testcase>')
+        self.assertEqual(self.warnings.return_junit_failures(), 2)
+


### PR DESCRIPTION
Counts number of failures in a JUnit xml file

note: the counting using regex is a bit different from the one above, as multiple failures can be on one line in a single line xml-file. We might want to change the regex statement for doxy/sphinx as well?

note: also made the --doxygen --sphinx options non exclusive... (elif --> if)