### PR TITLE
CodeClimate configuration needs to be adjusted

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        python:
+          mass_threshold: 40
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.py"
+  - "**.rb"
+exclude_paths:
+- tests/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ graft tests
 include README.rst
 include LICENSE
 
-include tox.ini .travis.yml
+include tox.ini .travis.yml .codeclimate.yml
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib
 


### PR DESCRIPTION
That is because they are not checking the issued marked as invalid and
we have lower score because of that. Current adjustment makes the
duplication detection limit higher, but that will also mean that it will
catch less errors. Once the issue on their side is fixed, we can again
move back to defaults.