### PR TITLE
Adding automated version from repo's git tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import io
 from glob import glob
 from os.path import basename, dirname, join, splitext
+import re
 
 from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/warnings-plugin'
-VERSION = '0.0.8'
 
 
 def read(*names, **kwargs):
@@ -15,13 +15,19 @@ def read(*names, **kwargs):
     ).read()
 
 
-requires = ['junitparser>=1.0.0']
+def get_property(prop, project):
+    result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop), open(project + '/__init__.py').read())
+    return result.group(1)
+
+
+requires = ['junitparser>=1.0.0', 'setuptools-scm']
+
 
 setup(
     name='mlx.warnings',
-    version=VERSION,
     url=PROJECT_URL,
-    download_url=PROJECT_URL + '/tarball/' + VERSION,
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     author='Bavo Van Achte',
     author_email='bavo.van.achte@gmail.com',
     description='Command-line alternative for https://github.com/jenkinsci/warnings-plugin. Useable with plugin-less CI systems.',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import io
 from glob import glob
 from os.path import basename, dirname, join, splitext
-import re
 
 from setuptools import find_packages, setup
 
@@ -13,11 +12,6 @@ def read(*names, **kwargs):
         join(dirname(__file__), *names),
         encoding=kwargs.get('encoding', 'utf8')
     ).read()
-
-
-def get_property(prop, project):
-    result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop), open(project + '/__init__.py').read())
-    return result.group(1)
 
 
 requires = ['junitparser>=1.0.0', 'setuptools-scm']

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -8,12 +8,15 @@ import sys
 import abc
 from junitparser import JUnitXml, Failure, Error
 import glob
+from setuptools_scm import get_version
 
 DOXYGEN_WARNING_REGEX = r"(?:((?:[/.]|[A-Za-z]).+?):(-?\d+):\s*([Ww]arning|[Ee]rror)|<.+>:-?\d+(?::\s*([Ww]arning|[Ee]rror))?): (.+(?:(?!\s*(?:[Nn]otice|[Ww]arning|[Ee]rror): )[^/<\n][^:\n][^/\n].+)*)|\s*([Nn]otice|[Ww]arning|[Ee]rror): (.+)\n?"
 doxy_pattern = re.compile(DOXYGEN_WARNING_REGEX)
 
 SPHINX_WARNING_REGEX = r"(.+?:(?:\d+|None)):\s*(DEBUG|INFO|WARNING|ERROR|SEVERE):\s*(.+)\n?"
 sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
+
+__version__ = get_version()
 
 
 class WarningsChecker(object):

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
     mlx-warnings -h
     mlx-warnings --version
+    python -c 'import mlx.warnings;print(mlx.warnings.__version__)'
     python -m mlx.warnings -h
     python -m mlx.warnings --version
     python -m mlx.warnings -j tests/junit*.xml --maxwarnings 3 --minwarnings 3
@@ -62,6 +63,7 @@ deps =
 deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-plantuml
+    junitparser>=1.0.0
 commands =
     sphinx-build {posargs:-E} -b doctest docs dist/docs
     sphinx-build {posargs:-E} -b html docs dist/docs
@@ -70,14 +72,12 @@ commands =
 [testenv:check]
 deps =
     docutils
-    check-manifest
-    flake8
     readme-renderer
+    flake8
     pygments
 skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
-    check-manifest {toxinidir} -u
     flake8 src tests setup.py
 
 [testenv:coveralls]


### PR DESCRIPTION
setuptools_scm is a good tool where you package one item per repo, so
you do not need to add commits when you want to release, but simply
change the tag in git and version will change by itself. It also takes
nicely care of the development versions with the `hash` and `dev`
attached to the name