### PR TITLE
Add automatic parsing of the stream

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,10 @@ You can do that with shell pipes or with
 command line arguments to command (if it supports outputting errors to file
 instead of stderr). Be aware that some commands print warnings on stdout.
 
+Also warnings plugin log files need to be the last argument as otherwise the
+arguments after that are discarded, because they are considered as command
+arguments (with or without command flag).
+
 ------------
 Pipe example
 ------------
@@ -83,7 +87,7 @@ required).
 
 .. code-block:: bash
 
-    mlx-warnings -c yourcommand
+    mlx-warnings --command yourcommand
 
 ---------------
 Running command
@@ -115,9 +119,9 @@ The command returns (shell $? variable):
 - value 0 when the number of counted warnings is within the supplied minimum and maximum limits: ok,
 - number of counted warnings (positive) when the counter number is not within those limit.
 
-----------------------------
+-------------------------
 Parse for Sphinx warnings
-----------------------------
+-------------------------
 
 After you saved your Sphinx warnings to the file, you can parse it with
 command:
@@ -130,8 +134,8 @@ command:
     mlx-warnings --command --sphinx commandforsphinx
 
     # explicitly as python module for log file
-    python3 -m mlx.warnings doc_log.txt --sphinx
-    python -m mlx.warnings doc_log.txt --sphinx
+    python3 -m mlx.warnings --sphinx doc_log.txt
+    python -m mlx.warnings --sphinx doc_log.txt
     # explicitly as python module
     python3 -m mlx.warnings --command --sphinx commandforsphinx
     python -m mlx.warnings --command --sphinx commandforsphinx
@@ -152,8 +156,8 @@ command:
     mlx-warnings --command --doxygen commandfordoxygen
 
     # explicitly as python module for log file
-    python3 -m mlx.warnings doc_log.txt --doxygen
-    python -m mlx.warnings doc_log.txt --doxygen
+    python3 -m mlx.warnings --doxygen doc_log.txt
+    python -m mlx.warnings --doxygen doc_log.txt
     # explicitly as python module
     python3 -m mlx.warnings --command --doxygen commandfordoxygen
     python -m mlx.warnings --command --doxygen commandfordoxygen
@@ -174,8 +178,8 @@ command:
     mlx-warnings --command --junit commandforjunit
 
     # explicitly as python module for log file
-    python3 -m mlx.warnings junit_output.xml --junit
-    python -m mlx.warnings junit_output.xml --junit
+    python3 -m mlx.warnings --junit junit_output.xml
+    python -m mlx.warnings --junit junit_output.xml
     # explicitly as python module
     python3 -m mlx.warnings --command --junit commandforjunit
     python -m mlx.warnings --command --junit commandforjunit

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,9 @@ You can find more details in `Installation guide <docs/installation.rst>`_
 Usage
 =====
 
-Since warnings plugin parses log messages (so far), you will need to redirect
-your stderr to some text file. You can do that with shell pipes or with
+Warnings plugin parses log messages as well as direct command stream. In case you
+want to create log file, you will need to redirect your stderr to some text file.
+You can do that with shell pipes or with
 command line arguments to command (if it supports outputting errors to file
 instead of stderr). Be aware that some commands print warnings on stdout.
 
@@ -73,6 +74,16 @@ file.
 
     yourcommand 2>&1 | tee doc_log.txt
 
+---------------
+Command example
+---------------
+
+Below is the command example for the plugin (keep in mind that parse commands are
+required).
+
+.. code-block:: bash
+
+    mlx-warnings -c yourcommand
 
 ---------------
 Running command
@@ -113,11 +124,17 @@ command:
 
 .. code-block:: bash
 
-    # command line
+    # command line log file
     mlx-warnings doc_log.txt --sphinx
-    # explicitly as python module
+    # command line command execution
+    mlx-warnings --command --sphinx commandforsphinx
+
+    # explicitly as python module for log file
     python3 -m mlx.warnings doc_log.txt --sphinx
     python -m mlx.warnings doc_log.txt --sphinx
+    # explicitly as python module
+    python3 -m mlx.warnings --command --sphinx commandforsphinx
+    python -m mlx.warnings --command --sphinx commandforsphinx
 
 
 --------------------------
@@ -129,11 +146,17 @@ command:
 
 .. code-block:: bash
 
-    # command line
+    # command line log file
     mlx-warnings doc_log.txt --doxygen
-    # explicitly as python module
+    # command line command execution
+    mlx-warnings --command --doxygen commandfordoxygen
+
+    # explicitly as python module for log file
     python3 -m mlx.warnings doc_log.txt --doxygen
     python -m mlx.warnings doc_log.txt --doxygen
+    # explicitly as python module
+    python3 -m mlx.warnings --command --doxygen commandfordoxygen
+    python -m mlx.warnings --command --doxygen commandfordoxygen
 
 
 ------------------------
@@ -145,11 +168,17 @@ command:
 
 .. code-block:: bash
 
-    # command line
+    # command line log file
     mlx-warnings junit_output.xml --junit
-    # explicitly as python module
+    # command line command execution
+    mlx-warnings --command --junit commandforjunit
+
+    # explicitly as python module for log file
     python3 -m mlx.warnings junit_output.xml --junit
     python -m mlx.warnings junit_output.xml --junit
+    # explicitly as python module
+    python3 -m mlx.warnings --command --junit commandforjunit
+    python -m mlx.warnings --command --junit commandforjunit
 
 -------------
 Other options

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ required).
 
 .. code-block:: bash
 
-    mlx-warnings --command yourcommand
+    mlx-warnings --command <yourcommand>
 
 ---------------
 Running command
@@ -131,14 +131,14 @@ command:
     # command line log file
     mlx-warnings doc_log.txt --sphinx
     # command line command execution
-    mlx-warnings --command --sphinx commandforsphinx
+    mlx-warnings --command --sphinx <commandforsphinx>
 
     # explicitly as python module for log file
     python3 -m mlx.warnings --sphinx doc_log.txt
     python -m mlx.warnings --sphinx doc_log.txt
     # explicitly as python module
-    python3 -m mlx.warnings --command --sphinx commandforsphinx
-    python -m mlx.warnings --command --sphinx commandforsphinx
+    python3 -m mlx.warnings --command --sphinx <commandforsphinx>
+    python -m mlx.warnings --command --sphinx <commandforsphinx>
 
 
 --------------------------
@@ -153,14 +153,14 @@ command:
     # command line log file
     mlx-warnings doc_log.txt --doxygen
     # command line command execution
-    mlx-warnings --command --doxygen commandfordoxygen
+    mlx-warnings --command --doxygen <commandfordoxygen>
 
     # explicitly as python module for log file
     python3 -m mlx.warnings --doxygen doc_log.txt
     python -m mlx.warnings --doxygen doc_log.txt
     # explicitly as python module
-    python3 -m mlx.warnings --command --doxygen commandfordoxygen
-    python -m mlx.warnings --command --doxygen commandfordoxygen
+    python3 -m mlx.warnings --command --doxygen <commandfordoxygen>
+    python -m mlx.warnings --command --doxygen <commandfordoxygen>
 
 
 ------------------------
@@ -175,14 +175,14 @@ command:
     # command line log file
     mlx-warnings junit_output.xml --junit
     # command line command execution
-    mlx-warnings --command --junit commandforjunit
+    mlx-warnings --command --junit <commandforjunit>
 
     # explicitly as python module for log file
     python3 -m mlx.warnings --junit junit_output.xml
     python -m mlx.warnings --junit junit_output.xml
     # explicitly as python module
-    python3 -m mlx.warnings --command --junit commandforjunit
-    python -m mlx.warnings --command --junit commandforjunit
+    python3 -m mlx.warnings --command --junit <commandforjunit>
+    python -m mlx.warnings --command --junit <commandforjunit>
 
 -------------
 Other options

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -317,7 +317,7 @@ def warnings_wrapper(args):
     group.add_argument('-s', '--sphinx', dest='sphinx', action='store_true')
     group.add_argument('-j', '--junit', dest='junit', action='store_true')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
-    parser.add_argument('-c', '--command', dest='command', action='store_true',
+    parser.add_argument('--command', dest='command', action='store_true',
                         help='Treat program arguments as command to execute to obtain data')
     parser.add_argument('-m', '--maxwarnings', type=int, required=False, default=0,
                         help='Maximum amount of warnings accepted')
@@ -326,6 +326,7 @@ def warnings_wrapper(args):
     parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=pkg_resources.require('mlx.warnings')[0].version))
 
     parser.add_argument('logfile', nargs='+', help='Logfile (or command) that might contain warnings')
+    parser.add_argument('flags', nargs=argparse.REMAINDER, help='Possible not-used flags from above are considered as command flags')
 
     args = parser.parse_args(args)
 
@@ -334,7 +335,10 @@ def warnings_wrapper(args):
     warnings.set_minimum(args.minwarnings)
 
     if args.command:
-        warnings_command(warnings, args.logfile)
+        cmd = args.logfile
+        if args.flags:
+            cmd.extend(args.flags)
+        warnings_command(warnings, cmd)
     else:
         warnings_logfile(warnings, args.logfile)
 

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -372,8 +372,7 @@ def warnings_command(warnings, cmd):
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             print("It seems like program " + str(cmd) + " is not installed.")
-        else:
-            raise
+        raise
 
 
 def warnings_logfile(warnings, log):

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -317,7 +317,7 @@ def warnings_wrapper(args):
     group.add_argument('-s', '--sphinx', dest='sphinx', action='store_true')
     group.add_argument('-j', '--junit', dest='junit', action='store_true')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
-    parser.add_argument('-c', '--command', dest='command', action='store_true' help='Treat program arguments as command to execute to obtain data')
+    parser.add_argument('-c', '--command', dest='command', action='store_true', help='Treat program arguments as command to execute to obtain data')
     parser.add_argument('-m', '--maxwarnings', type=int, required=False, default=0,
                         help='Maximum amount of warnings accepted')
     parser.add_argument('--minwarnings', type=int, required=False, default=0,

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -317,7 +317,7 @@ def warnings_wrapper(args):
     group.add_argument('-s', '--sphinx', dest='sphinx', action='store_true')
     group.add_argument('-j', '--junit', dest='junit', action='store_true')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
-    parser.add_argument('-c', '--command', dest='command', action='store_true')
+    parser.add_argument('-c', '--command', dest='command', action='store_true' help='Treat program arguments as command to execute to obtain data')
     parser.add_argument('-m', '--maxwarnings', type=int, required=False, default=0,
                         help='Maximum amount of warnings accepted')
     parser.add_argument('--minwarnings', type=int, required=False, default=0,

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -317,7 +317,8 @@ def warnings_wrapper(args):
     group.add_argument('-s', '--sphinx', dest='sphinx', action='store_true')
     group.add_argument('-j', '--junit', dest='junit', action='store_true')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
-    parser.add_argument('-c', '--command', dest='command', action='store_true', help='Treat program arguments as command to execute to obtain data')
+    parser.add_argument('-c', '--command', dest='command', action='store_true',
+                        help='Treat program arguments as command to execute to obtain data')
     parser.add_argument('-m', '--maxwarnings', type=int, required=False, default=0,
                         help='Maximum amount of warnings accepted')
     parser.add_argument('--minwarnings', type=int, required=False, default=0,
@@ -325,8 +326,10 @@ def warnings_wrapper(args):
     parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=pkg_resources.require('mlx.warnings')[0].version))
 
     parser.add_argument('logfile', nargs='+', help='Logfile (or command) that might contain warnings')
-    args = parser.parse_args(args)
 
+    return warnings_exec(parser.parse_args(args))
+
+def warnings_exec(args):
     warnings = WarningsPlugin(sphinx=args.sphinx, doxygen=args.doxygen, junit=args.junit, verbose=args.verbose)
     warnings.set_maximum(args.maxwarnings)
     warnings.set_minimum(args.minwarnings)

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import argparse
 import os
 import pkg_resources
@@ -333,12 +335,22 @@ def warnings_wrapper(args):
         try:
             proc = subprocess.Popen(args.logfile, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
             out, err = proc.communicate()
-            # Check stderr
-            if err:
-                warnings.check(err.decode(encoding="utf-8"))
             # Check stdout
             if out:
-                warnings.check(out.decode(encoding="utf-8"))
+                try:
+                    warnings.check(out.decode(encoding="utf-8"))
+                    print(out.decode(encoding="utf-8"))
+                except AttributeError as e:
+                    warnings.check(out)
+                    print(out)
+            # Check stderr
+            if err:
+                try:
+                    warnings.check(err.decode(encoding="utf-8"))
+                    print(err.decode(encoding="utf-8"), file=sys.stderr)
+                except AttributeError as e:
+                    warnings.check(err)
+                    print(err, file=sys.stderr)
         except OSError as e:
             if e.errno == os.errno.ENOENT:
                 print("It seems like program " + str(args.logfile) + " is not installed.")

--- a/tests/sphinx_double_warning.txt
+++ b/tests/sphinx_double_warning.txt
@@ -1,0 +1,3 @@
+/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'
+/home/bljah/test/index.rst:None: WARNING: toctree contains reference to nonexisting document u'installation'
+

--- a/tests/sphinx_single_warning.txt
+++ b/tests/sphinx_single_warning.txt
@@ -1,0 +1,2 @@
+/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,6 +27,10 @@ class TestIntegration(TestCase):
         retval = warnings_wrapper(['--sphinx', '--command', 'cat', '-A', 'tests/sphinx_single_warning.txt', 'tests/sphinx_double_warning.txt'])
         self.assertEqual(1 + 2, retval)
 
+    def test_command_to_stderr(self):
+        retval = warnings_wrapper(['--sphinx', '--command', 'cat', 'tests/sphinx_single_warning.txt', '>&2'])
+        self.assertEqual(1, retval)
+
     def test_wildcarded_arguments(self):
         # note: no shell expansion simulation (e.g. as in windows)
         retval = warnings_wrapper(['--junit', 'tests/junit*.xml'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,7 +20,7 @@ class TestIntegration(TestCase):
         self.assertEqual(1, retval)
 
     def test_two_command_arguments(self):
-        retval = warnings_wrapper(['--junit', '--command', 'cat', 'tests/junit_single_fail.xml', 'tests/junit_double_fail.xml'])
+        retval = warnings_wrapper(['--sphinx', '--command', 'cat', 'tests/sphinx_single_warning.txt', 'tests/sphinx_double_warning.txt'])
         self.assertEqual(1 + 2, retval)
 
     def test_wildcarded_arguments(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,14 @@ class TestIntegration(TestCase):
         retval = warnings_wrapper(['--junit', 'tests/junit_single_fail.xml', 'tests/junit_double_fail.xml'])
         self.assertEqual(1 + 2, retval)
 
+    def test_single_command_argument(self):
+        retval = warnings_wrapper(['--junit', '--command', 'cat', 'tests/junit_single_fail.xml'])
+        self.assertEqual(1, retval)
+
+    def test_two_command_arguments(self):
+        retval = warnings_wrapper(['--junit', '--command', 'cat', 'tests/junit_single_fail.xml', 'tests/junit_double_fail.xml'])
+        self.assertEqual(1 + 2, retval)
+
     def test_wildcarded_arguments(self):
         # note: no shell expansion simulation (e.g. as in windows)
         retval = warnings_wrapper(['--junit', 'tests/junit*.xml'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,6 +31,10 @@ class TestIntegration(TestCase):
         retval = warnings_wrapper(['--sphinx', '--command', 'cat', 'tests/sphinx_single_warning.txt', '>&2'])
         self.assertEqual(1, retval)
 
+    def test_faulty_command(self):
+        with self.assertRaises(OSError):
+            warnings_wrapper(['--sphinx', '--command', 'blahahahaha', 'tests/sphinx_single_warning.txt'])
+
     def test_wildcarded_arguments(self):
         # note: no shell expansion simulation (e.g. as in windows)
         retval = warnings_wrapper(['--junit', 'tests/junit*.xml'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,6 +23,10 @@ class TestIntegration(TestCase):
         retval = warnings_wrapper(['--sphinx', '--command', 'cat', 'tests/sphinx_single_warning.txt', 'tests/sphinx_double_warning.txt'])
         self.assertEqual(1 + 2, retval)
 
+    def test_command_with_its_own_arguments(self):
+        retval = warnings_wrapper(['--sphinx', '--command', 'cat', '-A', 'tests/sphinx_single_warning.txt', 'tests/sphinx_double_warning.txt'])
+        self.assertEqual(1 + 2, retval)
+
     def test_wildcarded_arguments(self):
         # note: no shell expansion simulation (e.g. as in windows)
         retval = warnings_wrapper(['--junit', 'tests/junit*.xml'])

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
     python -m mlx.warnings --version
     python -m mlx.warnings -j tests/junit*.xml --maxwarnings 3 --minwarnings 3
     python -m mlx.warnings -j "tests/junit*.xml" --maxwarnings 3 --minwarnings 3 #emulate for windows (no shell expansion)
+    python -m mlx.warnings -j -c --maxwarnings 2 --minwarnings 2 cat tests/junit_double_fail.xml
 
 [testenv:bootstrap]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,9 @@ commands =
     python -c 'import mlx.warnings;print(mlx.warnings.__version__)'
     python -m mlx.warnings -h
     python -m mlx.warnings --version
-    python -m mlx.warnings -j tests/junit*.xml --maxwarnings 3 --minwarnings 3
-    python -m mlx.warnings -j "tests/junit*.xml" --maxwarnings 3 --minwarnings 3 #emulate for windows (no shell expansion)
-    python -m mlx.warnings -j -c --maxwarnings 2 --minwarnings 2 cat tests/junit_double_fail.xml
+    python -m mlx.warnings -j --maxwarnings 3 --minwarnings 3 tests/junit*.xml
+    python -m mlx.warnings -j --maxwarnings 3 --minwarnings 3 "tests/junit*.xml"  #emulate for windows (no shell expansion)
+    python -m mlx.warnings -j --command --maxwarnings 2 --minwarnings 2 cat tests/junit_double_fail.xml
 
 [testenv:bootstrap]
 deps =


### PR DESCRIPTION
Since tox does not like pipes and stuff we need to adjust plugin so that you do not have to deal with logs. This allows us to execute the command, parse stdout for errors (and print it), parse stderr for errors (and print it), which eliminates the need for any log files whatsoever.

One of the side effects of this is that stdout and stderr are not aligned in logs (stderr is printed first, stdout second), but implementation where we print out live the data line by line is a bit more complicated.

This closes #3 