### PR TITLE
Remove deployment to test.pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,19 +55,6 @@ notifications:
     on_failure: always
 
 deploy:
-  # test pypi
-  - provider: pypi
-    distributions: sdist bdist_wheel
-    server: https://test.pypi.org/legacy/
-    user: bavo.van.achte
-    password:
-      secure: cKCBgEUOSUnlPbOxHCrXENlVgdMGnjNC+7nnutp/1xF8VEDF3aj9Br4u5LKrAYs0sm0AvnCyjhPvfKGPwyRDdfGBjoG06G+L+1hcfpgBlItmdSBqB8RxMm2B76si1ZlVI9gC58hlk/agFr2vik/mLXsH23rafB/2UwfB3ItTTx2J14xC5jlaqYR/srMJUi8YO5z6mGGLokfcz0KhYUHegOna38UcARM8rkAC2Je0xrPKZMlCoTI84dqwnFPW4zn3g/B5s3s18gmZu4fE4+J1g0PNMvxhbDP1TIBzPSWXLBv+YPSKrIT6+Q4R/kfDJFzLn3SmDDnNOpD/OC8ssqVJOcQL3HhKQ7EAcxX9W+/Rt7mIpdJdDXohiPrBl9EdRYbhB+KiPeo/dekAV6loUP/8cHuEgjcW/gE8t+HIqWsa5SO9yK7Sz8Ym+0ENdzS1df0iPOj2ebR3kb1iwINdFi7zIG6Utvlf7w1A2Qtx1xfI2+woPU+GOgQrpwdw64Wl1uo4l0kqTpFkytIG7BEVWC+zPPzqddi+3Ulf9AkWSjNDTqYafxZ9oqBJ5q7WPH8zyPQHotcHbnziTAnv7qRa+CTFLeME/KXNT8egToLK75G367lANTFIhMm8eSDS7wAxFWHacq8j68wNb38Yj1Rv1WMHQh14sxOkzQ4hVEV0xYY7Bj8=
-    before_deploy:
-      - "env SETUP_TOOLS_SCM_PRETEND_VERSION='{next_version}.dev{distance}'"
-    on:
-      branch: master
-      python: 3.6
-      tags: false
   # production pypi
   - provider: pypi
     distributions: sdist bdist_wheel


### PR DESCRIPTION
We can not force setuptools_scm env variable just for this one deployment. We would need to set variable just in the deploy command of the test-pypi as discussed in https://github.com/pypa/setuptools_scm/issues/217 , but that is not possible as deploy does not take `env`, `before_deploy`,`before_script` commands at all. That is already a feature request for travis-ci https://github.com/travis-ci/travis-ci/issues/6532 and since I would not like to loose any more time I will just remove deployment to test-pypi. 

If someone has an option to fix this while keeping automatic versioning of setuptools_scm, we can always re-add.