### PR TITLE
Respect executed command return value

### DIFF
--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -340,8 +340,9 @@ def warnings_wrapper(args):
         cmd = args.logfile
         if args.flags:
             cmd.extend(args.flags)
-        retval = warnings_command(warnings, cmd, args.ignore)
-        if retval != 0:
+        retval = warnings_command(warnings, cmd)
+
+        if (not args.ignore) and (retval != 0):
             return retval
     else:
         warnings_logfile(warnings, args.logfile)
@@ -350,7 +351,7 @@ def warnings_wrapper(args):
     return warnings.return_check_limits()
 
 
-def warnings_command(warnings, cmd, ignore):
+def warnings_command(warnings, cmd):
     ''' Execute command to obtain input for parsing for warnings
 
     Usually log files are output of the commands. To avoid this additional step
@@ -364,7 +365,6 @@ def warnings_command(warnings, cmd, ignore):
 
     Return:
         retval: Return value of executed command
-        0: If ignore flag is used.
 
     Raises:
         OSError: When program is not installed.
@@ -392,11 +392,7 @@ def warnings_command(warnings, cmd, ignore):
             except AttributeError as e:
                 warnings.check(err)
                 print(err, file=sys.stderr)
-
-        if ignore:
-            return 0
-        else:
-            return proc.returncode
+        return proc.returncode
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             print("It seems like program " + str(cmd) + " is not installed.")

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -213,6 +213,7 @@ class WarningsPlugin:
         self.warn_min = 0
         self.warn_max = 0
         self.count = 0
+        self.printout = False
 
     def activate_checker(self, checker):
         '''
@@ -244,6 +245,8 @@ class WarningsPlugin:
         if len(self.checkerList) == 0:
             print("No checkers activated. Please use activate_checker function")
         else:
+            if self.printout:
+                print(content)
             for name, checker in self.checkerList.items():
                 checker.check(content)
 
@@ -309,6 +312,16 @@ class WarningsPlugin:
 
         return 0
 
+    def toggle_printout(self, printout):
+        ''' Toggle printout of all the parsed content
+
+        Useful for command input where we want to print content as well
+
+        Args:
+            printout: True enables the printout, False provides more silent mode
+        '''
+        self.printout = printout
+
 
 def warnings_wrapper(args):
     parser = argparse.ArgumentParser(prog='mlx-warnings')
@@ -340,6 +353,7 @@ def warnings_wrapper(args):
         cmd = args.logfile
         if args.flags:
             cmd.extend(args.flags)
+        warnings.toggle_printout(True)
         retval = warnings_command(warnings, cmd)
 
         if (not args.ignore) and (retval != 0):
@@ -379,19 +393,15 @@ def warnings_command(warnings, cmd):
         # Check stdout
         if out:
             try:
-                print(out.decode(encoding="utf-8"))
                 warnings.check(out.decode(encoding="utf-8"))
             except AttributeError as e:
                 warnings.check(out)
-                print(out)
         # Check stderr
         if err:
             try:
                 warnings.check(err.decode(encoding="utf-8"))
-                print(err.decode(encoding="utf-8"), file=sys.stderr)
             except AttributeError as e:
                 warnings.check(err)
-                print(err, file=sys.stderr)
         return proc.returncode
     except OSError as e:
         if e.errno == os.errno.ENOENT:

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -338,7 +338,9 @@ def warnings_wrapper(args):
         cmd = args.logfile
         if args.flags:
             cmd.extend(args.flags)
-        warnings_command(warnings, cmd)
+        retval = warnings_command(warnings, cmd)
+        if retval != 0:
+            return retval
     else:
         warnings_logfile(warnings, args.logfile)
 
@@ -369,6 +371,7 @@ def warnings_command(warnings, cmd):
             except AttributeError as e:
                 warnings.check(err)
                 print(err, file=sys.stderr)
+        return proc.returncode
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             print("It seems like program " + str(cmd) + " is not installed.")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -50,6 +50,10 @@ class TestIntegration(TestCase):
         with self.assertRaises(OSError):
             warnings_wrapper(['--sphinx', '--command', 'blahahahaha', 'tests/sphinx_single_warning.txt'])
 
+    def test_command_revtal_err(self):
+        retval = warnings_wrapper(['--sphinx', '--command', 'false'])
+        self.assertEqual(1, retval)
+
     def test_wildcarded_arguments(self):
         # note: no shell expansion simulation (e.g. as in windows)
         retval = warnings_wrapper(['--junit', 'tests/junit*.xml'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,6 +54,10 @@ class TestIntegration(TestCase):
         retval = warnings_wrapper(['--sphinx', '--command', 'false'])
         self.assertEqual(1, retval)
 
+    def test_command_revtal_err_supress(self):
+        retval = warnings_wrapper(['--sphinx', '--ignore-retval', '--command', 'false'])
+        self.assertEqual(0, retval)
+
     def test_wildcarded_arguments(self):
         # note: no shell expansion simulation (e.g. as in windows)
         retval = warnings_wrapper(['--junit', 'tests/junit*.xml'])


### PR DESCRIPTION
This is a bugfix for #55 where we did not respect the return value of the command by default. This meant we still parsed for warnings and made our decision on that, even though the command has failed. Now by default we abide the return value of the command but we still add a flag to ignore it. Ignore currently just ignores it, but we might have a better "worse case" ignore, where it would be ignored if there is no output on either stderr or stdout, but otherwise it would still be passing through the checks.

Closes #55 