### PR TITLE
Open file check

### DIFF
--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -359,7 +359,9 @@ def warnings_wrapper(args):
         if (not args.ignore) and (retval != 0):
             return retval
     else:
-        warnings_logfile(warnings, args.logfile)
+        retval = warnings_logfile(warnings, args.logfile)
+        if retval != 0:
+            return retval
 
     warnings.return_count()
     return warnings.return_check_limits()
@@ -383,7 +385,6 @@ def warnings_command(warnings, cmd):
     Raises:
         OSError: When program is not installed.
     '''
-
     try:
         print("Executing: ", end='')
         print(cmd)
@@ -410,6 +411,16 @@ def warnings_command(warnings, cmd):
 
 
 def warnings_logfile(warnings, log):
+    ''' Parse logfile for warnings
+
+    Args:
+        warnings (WarningsPlugin): Object for warnings where errors should be logged
+        log: Logfile for parsing
+
+    Return:
+        0: Log files existed and are parsed successfully
+        1: Log files did not exist
+    '''
     # args.logfile doesn't necessarily contain wildcards, but just to be safe, we
     # assume it does, and try to expand them.
     # This mechanism is put in place to allow wildcards to be passed on even when
@@ -417,9 +428,15 @@ def warnings_logfile(warnings, log):
     # so that the script can be used in the exact same way even when moving from one
     # OS to another.
     for file_wildcard in log:
-        for logfile in glob.glob(file_wildcard):
-            with open(logfile, 'r') as loghandle:
-                warnings.check(loghandle.read())
+        if glob.glob(file_wildcard):
+            for logfile in glob.glob(file_wildcard):
+                with open(logfile, 'r') as loghandle:
+                    warnings.check(loghandle.read())
+        else:
+            print("FILE: %s does not exist" % file_wildcard)
+            return 1
+
+    return 0
 
 
 def main():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,6 +30,10 @@ class TestIntegration(TestCase):
         retval = warnings_wrapper(['--junit', 'tests/junit_single_fail.xml', 'tests/junit_double_fail.xml'])
         self.assertEqual(1 + 2, retval)
 
+    def test_non_existing_logfile(self):
+        retval = warnings_wrapper(['--sphinx', 'not-exist.log'])
+        self.assertEqual(1, retval)
+
     def test_single_command_argument(self):
         retval = warnings_wrapper(['--junit', '--command', 'cat', 'tests/junit_single_fail.xml'])
         self.assertEqual(1, retval)


### PR DESCRIPTION
Windows wildcard expansion resulted in us parsing empty files and returning success (0) with that.

Closes #54 