### PR TITLE
Python xmlrunner parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ stages:
   - name: coverity
     if: tag
   - name: deploy
+    if: tag
 
 jobs:
   include:

--- a/README.rst
+++ b/README.rst
@@ -196,6 +196,30 @@ command:
     python -m mlx.warnings --junit --command <commandforjunit>
 
 
+Parse for XMLRunner errors
+--------------------------
+
+When you run [XMLRunner](https://github.com/xmlrunner/unittest-xml-reporting)
+the errors are reported on the output, but they are not marked as failures in
+the test reports xml files. Since command exits as 1, we could not detect tests
+that just did not run (not failed). warnings-plugin now parses for the output
+with command:
+
+.. code-block:: bash
+
+    # command line log file
+    mlx-warnings xmlrunner_log.txt --xmlrunner
+    # command line command execution
+    mlx-warnings --xmlrunner --command <commandforxmlrunner>
+
+    # explicitly as python module for log file
+    python3 -m mlx.warnings --xmlrunner xmlrunner_log.txt
+    python -m mlx.warnings --xmlrunner xmlrunner_log.txt
+    # explicitly as python module
+    python3 -m mlx.warnings --xmlrunner --command <commandforxmlrunner>
+    python -m mlx.warnings --xmlrunner --command <commandforxmlrunner>
+
+
 ----------------------------------
 Configuration file to pass options
 ----------------------------------

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -10,7 +10,7 @@ import pkg_resources
 import subprocess
 import sys
 import glob
-from mlx.warnings_checker import SphinxChecker, DoxyChecker, JUnitChecker
+from mlx.warnings_checker import SphinxChecker, DoxyChecker, JUnitChecker, XMLRunnerChecker
 from setuptools_scm import get_version
 
 __version__ = get_version()
@@ -28,7 +28,8 @@ class WarningsPlugin:
         '''
         self.checkerList = {}
         self.verbose = verbose
-        self.publicCheckers = [SphinxChecker(self.verbose), DoxyChecker(self.verbose), JUnitChecker(self.verbose)]
+        self.publicCheckers = [SphinxChecker(self.verbose), DoxyChecker(self.verbose), JUnitChecker(self.verbose),
+                               XMLRunnerChecker(self.verbose)]
 
         if configfile is not None:
             with open(configfile, 'r') as f:
@@ -186,6 +187,7 @@ def warnings_wrapper(args):
     group1.add_argument('-d', '--doxygen', dest='doxygen', action='store_true')
     group1.add_argument('-s', '--sphinx', dest='sphinx', action='store_true')
     group1.add_argument('-j', '--junit', dest='junit', action='store_true')
+    group1.add_argument('-x', '--xmlrunner', dest='xmlrunner', action='store_true')
     group1.add_argument('-m', '--maxwarnings', type=int, required=False, default=0,
                         help='Maximum amount of warnings accepted')
     group1.add_argument('--minwarnings', type=int, required=False, default=0,
@@ -217,6 +219,8 @@ def warnings_wrapper(args):
             warnings.activate_checker_name('doxygen')
         if args.junit:
             warnings.activate_checker_name('junit')
+        if args.xmlrunner:
+            warnings.activate_checker_name('xmlrunner')
         warnings.set_maximum(args.maxwarnings)
         warnings.set_minimum(args.minwarnings)
 

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -16,6 +16,7 @@ sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 PYTHON_XMLRUNNER_REGEX = r"(\s*(ERROR|FAILED) (\[\d+.\d\d\ds\]: \s*(.+)))\n?"
 xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 
+
 class WarningsChecker(object):
     name = 'checker'
 

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -13,6 +13,8 @@ doxy_pattern = re.compile(DOXYGEN_WARNING_REGEX)
 SPHINX_WARNING_REGEX = r"(.+?:(?:\d+|None)?):?\s*(DEBUG|INFO|WARNING|ERROR|SEVERE):\s*(.+)\n?"
 sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 
+PYTHON_XMLRUNNER_REGEX = r"(\s*(ERROR|FAILED) (\[\d+.\d\d\ds\]: \s*(.+)))\n?"
+xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 
 class WarningsChecker(object):
     name = 'checker'
@@ -148,6 +150,11 @@ class SphinxChecker(RegexChecker):
 class DoxyChecker(RegexChecker):
     name = 'doxygen'
     pattern = doxy_pattern
+
+
+class XMLRunnerChecker(RegexChecker):
+    name = 'xmlrunner'
+    pattern = xmlrunner_pattern
 
 
 class JUnitChecker(WarningsChecker):

--- a/tests/config_example.json
+++ b/tests/config_example.json
@@ -13,5 +13,10 @@
         "enabled": false,
         "min": 0,
         "max": 0
+    },
+    "xmlrunner":{
+        "enabled": false,
+        "min": 0,
+        "max": 0
     }
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mlx.warnings import WarningsPlugin, SphinxChecker, DoxyChecker, JUnitChecker
+from mlx.warnings import WarningsPlugin, SphinxChecker, DoxyChecker, JUnitChecker, XMLRunnerChecker
 
 
 class TestConfig(TestCase):
@@ -13,6 +13,8 @@ class TestConfig(TestCase):
         warnings.check("/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'")
         self.assertEqual(warnings.return_count(), 1)
         warnings.check('This should not be treated as warning2')
+        self.assertEqual(warnings.return_count(), 1)
+        warnings.check('ERROR [0.000s]: test_some_error_test (something.anything.somewhere)')
         self.assertEqual(warnings.return_count(), 1)
 
     def test_partial_sphinx_config_parsing(self):
@@ -30,6 +32,8 @@ class TestConfig(TestCase):
         self.assertEqual(warnings.return_count(), 0)
         with open('tests/junit_single_fail.xml', 'r') as xmlfile:
             warnings.check(xmlfile.read())
+        self.assertEqual(warnings.return_count(), 0)
+        warnings.check('ERROR [0.000s]: test_some_error_test (something.anything.somewhere)')
         self.assertEqual(warnings.return_count(), 0)
         warnings.check("/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'")
         self.assertEqual(warnings.return_count(), 1)
@@ -50,6 +54,8 @@ class TestConfig(TestCase):
         self.assertEqual(warnings.return_count(), 0)
         warnings.check("/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'")
         self.assertEqual(warnings.return_count(), 0)
+        warnings.check('ERROR [0.000s]: test_some_error_test (something.anything.somewhere)')
+        self.assertEqual(warnings.return_count(), 0)
         warnings.check('testfile.c:6: warning: group test: ignoring title "Some test functions" that does not match old title "Some freaky test functions"')
         self.assertEqual(warnings.return_count(), 1)
 
@@ -68,8 +74,31 @@ class TestConfig(TestCase):
         self.assertEqual(warnings.return_count(), 0)
         warnings.check('testfile.c:6: warning: group test: ignoring title "Some test functions" that does not match old title "Some freaky test functions"')
         self.assertEqual(warnings.return_count(), 0)
+        warnings.check('ERROR [0.000s]: test_some_error_test (something.anything.somewhere)')
+        self.assertEqual(warnings.return_count(), 0)
         with open('tests/junit_single_fail.xml', 'r') as xmlfile:
             warnings.check(xmlfile.read())
+        self.assertEqual(warnings.return_count(), 1)
+
+    def test_partial_xmlrunner_config_parsing(self):
+        warnings = WarningsPlugin()
+        tmpjson = {
+            'xmlrunner': {
+                'enabled': True,
+                'min': 0,
+                'max': 0
+            }
+        }
+
+        warnings.config_parser_json(tmpjson)
+        with open('tests/junit_single_fail.xml', 'r') as xmlfile:
+            warnings.check(xmlfile.read())
+        self.assertEqual(warnings.return_count(), 0)
+        warnings.check("/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'")
+        self.assertEqual(warnings.return_count(), 0)
+        warnings.check('testfile.c:6: warning: group test: ignoring title "Some test functions" that does not match old title "Some freaky test functions"')
+        self.assertEqual(warnings.return_count(), 0)
+        warnings.check('ERROR [0.000s]: test_some_error_test (something.anything.somewhere)')
         self.assertEqual(warnings.return_count(), 1)
 
     def test_doxy_junit_options_config_parsing(self):
@@ -166,6 +195,19 @@ class TestConfig(TestCase):
         warnings.config_parser_json(tmpjson)
         self.assertEqual(warnings.get_checker(JUnitChecker().name).get_maximum(), 5)
 
+    def test_xmlrunner_config_max(self):
+        warnings = WarningsPlugin()
+        tmpjson = {
+            'xmlrunner': {
+                'enabled': True,
+                'min': 0,
+                'max': 5
+            }
+        }
+
+        warnings.config_parser_json(tmpjson)
+        self.assertEqual(warnings.get_checker(XMLRunnerChecker().name).get_maximum(), 5)
+
     def test_all_config_max(self):
         warnings = WarningsPlugin()
         tmpjson = {
@@ -183,6 +225,11 @@ class TestConfig(TestCase):
                 'enabled': True,
                 'min': 0,
                 'max': 6
+            },
+            'xmlrunner': {
+                'enabled': True,
+                'min': 0,
+                'max': 6
             }
         }
 
@@ -190,6 +237,7 @@ class TestConfig(TestCase):
         self.assertEqual(warnings.get_checker(SphinxChecker().name).get_maximum(), 4)
         self.assertEqual(warnings.get_checker(DoxyChecker().name).get_maximum(), 5)
         self.assertEqual(warnings.get_checker(JUnitChecker().name).get_maximum(), 6)
+        self.assertEqual(warnings.get_checker(XMLRunnerChecker().name).get_maximum(), 6)
 
     def test_sphinx_config_min(self):
         warnings = WarningsPlugin()
@@ -230,6 +278,19 @@ class TestConfig(TestCase):
         warnings.config_parser_json(tmpjson)
         self.assertEqual(warnings.get_checker(JUnitChecker().name).get_minimum(), 5)
 
+    def test_xmlrunner_config_min(self):
+        warnings = WarningsPlugin()
+        tmpjson = {
+            'xmlrunner': {
+                'enabled': True,
+                'min': 5,
+                'max': 7
+            }
+        }
+
+        warnings.config_parser_json(tmpjson)
+        self.assertEqual(warnings.get_checker(XMLRunnerChecker().name).get_minimum(), 5)
+
     def test_all_config_min(self):
         warnings = WarningsPlugin()
         tmpjson = {
@@ -247,6 +308,11 @@ class TestConfig(TestCase):
                 'enabled': True,
                 'min': 5,
                 'max': 7
+            },
+            'xmlrunner': {
+                'enabled': True,
+                'min': 5,
+                'max': 7
             }
         }
 
@@ -254,4 +320,5 @@ class TestConfig(TestCase):
         self.assertEqual(warnings.get_checker(SphinxChecker().name).get_minimum(), 4)
         self.assertEqual(warnings.get_checker(DoxyChecker().name).get_minimum(), 3)
         self.assertEqual(warnings.get_checker(JUnitChecker().name).get_minimum(), 5)
+        self.assertEqual(warnings.get_checker(XMLRunnerChecker().name).get_minimum(), 5)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,6 +33,8 @@ class TestIntegration(TestCase):
     def test_non_existing_logfile(self):
         retval = warnings_wrapper(['--sphinx', 'not-exist.log'])
         self.assertEqual(1, retval)
+        retval = warnings_wrapper(['--xmlrunner', 'not-exist.log'])
+        self.assertEqual(1, retval)
 
     def test_single_command_argument(self):
         retval = warnings_wrapper(['--junit', '--command', 'cat', 'tests/junit_single_fail.xml'])

--- a/tests/test_xmlrunner.py
+++ b/tests/test_xmlrunner.py
@@ -23,7 +23,7 @@ class TestXMLRunnerWarnings(TestCase):
         with patch('sys.stdout', new=StringIO()) as fake_out:
             self.warnings.check(dut)
         self.assertEqual(self.warnings.return_count(), 1)
-        self.assertRegexpMatches(fake_out.getvalue(), dut)
+        self.assertIn(dut, fake_out.getvalue())
 
     def test_single_warning_mixed(self):
         dut1 = 'This1 should not be treated as warning'
@@ -34,7 +34,7 @@ class TestXMLRunnerWarnings(TestCase):
             self.warnings.check(dut2)
             self.warnings.check(dut3)
         self.assertEqual(self.warnings.return_count(), 1)
-        self.assertRegexpMatches(fake_out.getvalue(), dut2)
+        self.assertIn(dut2, fake_out.getvalue())
 
     def test_multiline(self):
         duterr1 = "ERROR [0.000s]: test_some_error_test (something.anything.somewhere) \"Some test functions\" that does not match old title \"Some freaky test functions\"\n"
@@ -46,6 +46,6 @@ class TestXMLRunnerWarnings(TestCase):
         with patch('sys.stdout', new=StringIO()) as fake_out:
             self.warnings.check(dut)
         self.assertEqual(self.warnings.return_count(), 2)
-        self.assertRegexpMatches(fake_out.getvalue(), duterr1)
-        self.assertRegexpMatches(fake_out.getvalue(), duterr2)
+        self.assertIn(duterr1, fake_out.getvalue())
+        self.assertIn(duterr2, fake_out.getvalue())
 

--- a/tests/test_xmlrunner.py
+++ b/tests/test_xmlrunner.py
@@ -1,0 +1,51 @@
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+from mock import patch
+from unittest import TestCase
+
+from mlx.warnings import WarningsPlugin
+
+
+class TestXMLRunnerWarnings(TestCase):
+    def setUp(self):
+        self.warnings = WarningsPlugin(verbose=True)
+        self.warnings.activate_checker_name('xmlrunner')
+
+    def test_no_warning(self):
+        dut = 'This should not be treated as warning'
+        self.warnings.check(dut)
+        self.assertEqual(self.warnings.return_count(), 0)
+
+    def test_single_warning(self):
+        dut = 'ERROR [0.000s]: test_some_error_test (something.anything.somewhere)'
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            self.warnings.check(dut)
+        self.assertEqual(self.warnings.return_count(), 1)
+        self.assertRegexpMatches(fake_out.getvalue(), dut)
+
+    def test_single_warning_mixed(self):
+        dut1 = 'This1 should not be treated as warning'
+        dut2 = 'ERROR [0.000s]: test_some_error_test (something.anything.somewhere)'
+        dut3 = 'This should not be treated as warning2'
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            self.warnings.check(dut1)
+            self.warnings.check(dut2)
+            self.warnings.check(dut3)
+        self.assertEqual(self.warnings.return_count(), 1)
+        self.assertRegexpMatches(fake_out.getvalue(), dut2)
+
+    def test_multiline(self):
+        duterr1 = "ERROR [0.000s]: test_some_error_test (something.anything.somewhere) \"Some test functions\" that does not match old title \"Some freaky test functions\"\n"
+        duterr2 = "ERROR [0.000s]: ignoring title \"Some test functions\" that does not match old title \"Some freaky test functions\"\n"
+        dut = "This1 should not be treated as warning\n"
+        dut += duterr1
+        dut += "This should not be treated as warning2\n"
+        dut += duterr2
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            self.warnings.check(dut)
+        self.assertEqual(self.warnings.return_count(), 2)
+        self.assertRegexpMatches(fake_out.getvalue(), duterr1)
+        self.assertRegexpMatches(fake_out.getvalue(), duterr2)
+


### PR DESCRIPTION
Test reports from xmlrunner claim there are no errors or warnings, yet on output it writes them as errors (rightly so). We want to deploy warnings plugin to detect them and fail the build.

This PR has implemented simple regex for ERRORS of the tests from xmlrunner in Python (unittest). 