### PR TITLE
Adding xmlrunner to README example configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,11 @@ Configuration file is in JSON format with a simple structure.
     	    "enabled": false,
     	    "min": 0,
     	    "max": 0
+        },
+        "xmlrunner":{
+    	    "enabled": false,
+    	    "min": 0,
+    	    "max": 0
         }
     }
 


### PR DESCRIPTION
One thing was missed by previous MR.