### PR TITLE
Fixing flake warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ pip-selfcheck.json
 # vim
 *.swp
 
+# Offline version file
+src/mlx/__warnings_version__.py

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -269,13 +269,13 @@ def warnings_command(warnings, cmd):
         if out:
             try:
                 warnings.check(out.decode(encoding="utf-8"))
-            except AttributeError as e:
+            except AttributeError:
                 warnings.check(out)
         # Check stderr
         if err:
             try:
                 warnings.check(err.decode(encoding="utf-8"))
-            except AttributeError as e:
+            except AttributeError:
                 warnings.check(err)
         return proc.returncode
     except OSError as e:

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -185,7 +185,7 @@ class JUnitChecker(WarningsChecker):
                                                               testname=testcase.name))
             result.update_statistics()
             self.count += result.errors + result.failures
-        except ParseError as _:
+        except ParseError:
             return
 
 


### PR DESCRIPTION
It seems like some flake warnings managed to slip by the CI. Meanwhile I also added to ignore any possible changes to dummy version file which is now overwritten when tox does the packaging and we do not want this to affect us.