### PR TITLE
WIP: Quick and dirty implementation of Coverity checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,6 @@ jobs:
             branch: master
             python: 3.6
     # Stage TEST
-    - stage: test
-      python: '2.7'
-      env:
-        - TOXENV=py27,codecov
     - python: '3.4'
       env:
         - TOXENV=py34,codecov
@@ -55,7 +51,7 @@ jobs:
         - TOXENV=py36,codecov
     # Stage COVERITY
     - stage: coverity
-      python: '2.7'
+      python: '3.6'
       env:
         # TOXENV=py27 COVERITY_SCAN_TOKEN
         - secure: "VjiASJr/DgmDA5Gpy021ZVWAImhTdeKP8PreWWMRQlw02ZT96Ro39M/wtNUPKbbvph9q6gMIfF9bjBRxxcgmp73evyfbZu1ScyFQ7poFOOlX59tduDsmTaLMOdF3/uM3SwPEQJ40fSFXiHfFP6j26aFUNOwa7fUPhQuZ8aGofBaoRocL3llsDURIi5DjZBG9WmmNnHKh6X95aex4svj6hRq4/8L1EQiuignrQZmLFePCKz/FQ+AIperZZQyNNE7umLE8yHuVLWjH0gpBqyVqis2KSv4rU281oN/madi9de40sRdBS1pkyjdaBEnUn7QAPa8cwwkzRKmmL+YYKGe2zBfVydNzH/+B+N+f+dExbmK2vnCgpucNb7qAh4+ESPTXiO+9KtKNRocs5dgIC4SyvXUNEgYGpg0MViQKHaqGFpI3E750jY2bfvnrk/2DB3aYlR2FHfdsct214j0Ask/4eEwKqcY/AljVbDOm0ELAlhmhz1OfmphIRBMZPCT0qGJ4+zlyoe+CbW62lNYdDn+V5jiz43VNbtuxTIzYACxe10sRx5uNOCHlskOoy8m9hpXNpOMAqfNry/Vt33Nm7UCK4J9WF+kD87So/xaux+FKYat07PbPAocBCjVp490szPqXAMfX2RapIdpwFsy+JSyh/buWibmTWG5HF6ImTagM5f8="

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(*names, **kwargs):
     ).read()
 
 
-requires = ['junitparser>=1.0.0']
+requires = ['junitparser>=1.0.0', 'mlx.coverity==0.0.8', 'python-decouple']
 
 setup(
     name='mlx.warnings',

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 envlist =
     clean,
     check,
-    {py27,py35},
+    {py35},
     docs
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    py27: {env:TOXPYTHON:python2.7}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     {py36,docs,spell}: {env:TOXPYTHON:python3.6}
@@ -23,7 +22,9 @@ deps =
     pytest
     pytest-travis-fold
     pytest-cov
+    python-decouple
     mock
+    mlx-coverity
     junitparser>=1.0.0
     setuptools_scm
     coverage
@@ -65,6 +66,7 @@ deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-plantuml
     junitparser>=1.0.0
+    mlx-coverity
 commands =
     sphinx-build {posargs:-E} -b doctest docs dist/docs
     sphinx-build {posargs:-E} -b html docs dist/docs


### PR DESCRIPTION
Pulled in Sphinx Coverity plugin, so that functions for querying
Coverity Connect Server could be used. The configuration is read from
.env file (or environment variables) while command to actually invoke
the plugin is

```
# install from package (make sure you are in virtual env)
pip3 install -e .

# run newly installed plugin
mlx-warnings --coverity bla
```

That is because we want to actually bypass argparse and required
logfile/command argument. It might be useful to use command here (like
`cov-commit-defects`) and then query the DB for results.

Drop of Python 2.7 support due to some strange tox-suds relationship.

Closes #47