### PR TITLE
Include Sphinx warnings without docname (e.g. from mlx.traceability)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ stages:
   - check
   - docs
   - test
-  - coverity
+  - name: coverity
+    if: tag
   - name: deploy
     if: tag
 

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -10,7 +10,7 @@ from junitparser import Error, Failure, JUnitXml
 DOXYGEN_WARNING_REGEX = r"(?:((?:[/.]|[A-Za-z]).+?):(-?\d+):\s*([Ww]arning|[Ee]rror)|<.+>:-?\d+(?::\s*([Ww]arning|[Ee]rror))?): ((?!notes).+(?:(?!\s*(?:[Nn]otice|[Ww]arning|[Ee]rror): )[^/<\n][^:\n][^/\n].+)*)|\s*(\b[Nn]otice|\b[Ww]arning|\b[Ee]rror): (?!notes)(.+)\n?"
 doxy_pattern = re.compile(DOXYGEN_WARNING_REGEX)
 
-SPHINX_WARNING_REGEX = r"(.+?:(?:\d+|None)?):?\s*(DEBUG|INFO|WARNING|ERROR|SEVERE|(?:\w+Sphinx\d+Warning)):\s*(.+)\n?"
+SPHINX_WARNING_REGEX = r"(?m)^(?:(.+?:(?:\d+|None)?):?\s*)?(DEBUG|INFO|WARNING|ERROR|SEVERE|(?:\w+Sphinx\d+Warning)):\s*(.+)$"
 sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 
 PYTHON_XMLRUNNER_REGEX = r"(\s*(ERROR|FAILED) (\[\d+.\d\d\ds\]: \s*(.+)))\n?"

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -73,3 +73,10 @@ class TestSphinxWarnings(TestCase):
             self.warnings.check(dut)
         self.assertEqual(self.warnings.return_count(), 1)
         self.assertEqual(fake_out.getvalue(), duterr1)
+
+    def test_warning_no_docname(self):
+        duterr1 = "WARNING: List item 'CL-UNDEFINED_CL_ITEM' in merge/pull request 138 is not defined as a checklist-item.\n"
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            self.warnings.check(duterr1)
+        self.assertEqual(self.warnings.return_count(), 1)
+        self.assertEqual(fake_out.getvalue(), duterr1)


### PR DESCRIPTION
Needed for https://github.com/melexis/sphinx-traceability-extension/pull/140