### PR TITLE
Add flag to exclude Sphinx deprecation warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -331,6 +331,14 @@ An example configuration for the sphinx checker is given below:
         }
     }
 
+Exclude Sphinx deprecation warnings
+-----------------------------------
+
+There is a special flag `--exclude-sphinx-deprecation` that lets the sphinx checker exclude
+Sphinx deprecation warnings. These warnings match the following regular expression:
+`RemovedInSphinx\\d+Warning`. Using this flag results in the same behavior as adding this
+regex to the configuration file as value for the `exclude` key for the sphinx checker.
+
 
 =======================
 Issues and new Features

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -175,7 +175,7 @@ class WarningsPlugin:
                     self.activate_checker(checker)
                     checker.set_maximum(int(config[checker.name]['max']))
                     checker.set_minimum(int(config[checker.name]['min']))
-                    checker.add_exclude_patterns(config[checker.name].get("exclude"))
+                    checker.add_patterns(config[checker.name].get("exclude"), checker.exclude_patterns)
                     print("Config parsing for {name} completed".format(name=checker.name))
             except KeyError as err:
                 print("Incomplete config. Missing: {key}".format(key=err))
@@ -196,8 +196,8 @@ def warnings_wrapper(args):
     group2 = parser.add_argument_group('Configuration file with options')
     group2.add_argument('--config', dest='configfile', action='store', required=False,
                         help='Config file in JSON format provides toggle of checkers and their limits')
-    group2.add_argument('--exclude-sphinx-deprecation', dest='exclude_sphinx_deprecation', action='store_true',
-                        help="Sphinx checker will exclude warnings matching (RemovedInSphinx\\d+Warning) regex")
+    group2.add_argument('--include-sphinx-deprecation', dest='include_sphinx_deprecation', action='store_true',
+                        help="Sphinx checker will include warnings matching (RemovedInSphinx\\d+Warning) regex")
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
     parser.add_argument('--command', dest='command', action='store_true',
                         help='Treat program arguments as command to execute to obtain data')
@@ -232,8 +232,8 @@ def warnings_wrapper(args):
         warnings.set_maximum(args.maxwarnings)
         warnings.set_minimum(args.minwarnings)
 
-    if args.exclude_sphinx_deprecation and 'sphinx' in warnings.activated_checkers.keys():
-        warnings.get_checker('sphinx').exclude_sphinx_deprecation()
+    if args.include_sphinx_deprecation and 'sphinx' in warnings.activated_checkers.keys():
+        warnings.get_checker('sphinx').include_sphinx_deprecation()
 
     if args.command:
         cmd = args.logfile

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -175,7 +175,7 @@ class WarningsPlugin:
                     self.activate_checker(checker)
                     checker.set_maximum(int(config[checker.name]['max']))
                     checker.set_minimum(int(config[checker.name]['min']))
-                    checker.set_exclude_patterns(config[checker.name].get("exclude"))
+                    checker.add_exclude_patterns(config[checker.name].get("exclude"))
                     print("Config parsing for {name} completed".format(name=checker.name))
             except KeyError as err:
                 print("Incomplete config. Missing: {key}".format(key=err))
@@ -196,6 +196,8 @@ def warnings_wrapper(args):
     group2 = parser.add_argument_group('Configuration file with options')
     group2.add_argument('--config', dest='configfile', action='store', required=False,
                         help='Config file in JSON format provides toggle of checkers and their limits')
+    group2.add_argument('--exclude-sphinx-deprecation', dest='exclude_sphinx_deprecation', action='store_true',
+                        help="Sphinx checker will exclude warnings matching (RemovedInSphinx\\d+Warning) regex")
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true')
     parser.add_argument('--command', dest='command', action='store_true',
                         help='Treat program arguments as command to execute to obtain data')
@@ -229,6 +231,9 @@ def warnings_wrapper(args):
             warnings.activate_checker_name('coverity')
         warnings.set_maximum(args.maxwarnings)
         warnings.set_minimum(args.minwarnings)
+
+    if args.exclude_sphinx_deprecation and 'sphinx' in warnings.activated_checkers.keys():
+        warnings.get_checker('sphinx').exclude_sphinx_deprecation()
 
     if args.command:
         cmd = args.logfile

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -49,7 +49,7 @@ class WarningsChecker:
         '''
         return
 
-    def set_exclude_patterns(self, exclude_regexes):
+    def add_exclude_patterns(self, exclude_regexes):
         ''' Abstract setter function for the exclude patterns list[re.Pattern]
 
         Args:
@@ -148,13 +148,12 @@ class RegexChecker(WarningsChecker):
     name = 'regex'
     pattern = None
 
-    def set_exclude_patterns(self, exclude_regexes):
+    def add_exclude_patterns(self, exclude_regexes):
         ''' Setter function for the exclude patterns list[re.Pattern]
 
         Args:
             exclude_regexes (list|None): List of regexes to ignore certain matched warning messages
         '''
-        self.exclude_patterns = []
         if exclude_regexes:
             if not isinstance(exclude_regexes, list):
                 raise TypeError("Excpected a list value for exclude key in configuration file; got {}"
@@ -196,6 +195,11 @@ class RegexChecker(WarningsChecker):
 class SphinxChecker(RegexChecker):
     name = 'sphinx'
     pattern = sphinx_pattern
+    sphinx_deprecation_regex = "RemovedInSphinx\\d+Warning"
+
+    def exclude_sphinx_deprecation(self):
+        ''' Adds the pattern for sphinx_deprecation_regex to the list patterns to exclude '''
+        self.add_exclude_patterns([self.sphinx_deprecation_regex])
 
 
 class DoxyChecker(RegexChecker):

--- a/tests/sphinx_double_deprecation_warning.txt
+++ b/tests/sphinx_double_deprecation_warning.txt
@@ -1,0 +1,4 @@
+/usr/local/lib/python3.7/dist-packages/sphinx/util/docutils.py:286: RemovedInSphinx30Warning: function based directive support is now deprecated. Use class based directive instead.
+  RemovedInSphinx30Warning)
+/usr/local/lib/python3.7/dist-packages/sphinx_rtd_theme/search.html:20: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
+  {{ super() }}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,8 +28,9 @@ class TestConfig(TestCase):
             self.assertEqual(warnings.return_count(), 0)
             deprecation_warning = 'sphinx/application.py:402: RemovedInSphinx20Warning: app.info() is now deprecated. Use sphinx.util.logging instead.'
             warnings.check(deprecation_warning)
-            self.assertEqual(warnings.return_count(), 0)  # ignored because of configured "exclude" regex
-            warnings.check("/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'")
+            self.assertEqual(warnings.return_count(), 0)
+            toctree_warning = "/home/bljah/test/index.rst:5: WARNING: toctree contains reference to nonexisting document u'installation'"
+            warnings.check(toctree_warning)
             self.assertEqual(warnings.return_count(), 0)  # ignored because of configured "exclude" regex
             warnings.check("home/bljah/test/index.rst:5: WARNING: this warning should not get excluded")
             self.assertEqual(warnings.return_count(), 1)
@@ -37,10 +38,17 @@ class TestConfig(TestCase):
             self.assertEqual(warnings.return_count(), 1)
             warnings.check('ERROR [0.000s]: test_some_error_test (something.anything.somewhere)')
             self.assertEqual(warnings.return_count(), 1)
-        excluded_deprecation_warning = "Excluded {!r} because of configured regex {!r}".format(deprecation_warning, "RemovedInSphinx\\d+Warning")
-        self.assertIn(excluded_deprecation_warning, verbose_output.getvalue())
+        excluded_toctree_warning = "Excluded {!r} because of configured regex {!r}".format(toctree_warning, "WARNING: toctree")
+        self.assertIn(excluded_toctree_warning, verbose_output.getvalue())
         warning_echo = "home/bljah/test/index.rst:5: WARNING: this warning should not get excluded"
         self.assertIn(warning_echo, verbose_output.getvalue())
+
+    def test_configfile_parsing_include_priority(self):
+        warnings = WarningsPlugin(verbose=True, config_file="tests/config_example_exclude.json")
+        warnings.get_checker('sphinx').include_sphinx_deprecation()
+        deprecation_warning = 'sphinx/application.py:402: RemovedInSphinx20Warning: app.info() is now deprecated. Use sphinx.util.logging instead.'
+        warnings.check(deprecation_warning)
+        self.assertEqual(warnings.return_count(), 1)
 
     def test_partial_sphinx_config_parsing(self):
         warnings = WarningsPlugin()
@@ -118,7 +126,7 @@ class TestConfig(TestCase):
         with self.assertRaises(Exception) as exc:
             warnings.config_parser_json(tmpjson)
         self.assertEqual(str(exc.exception),
-                         "Feature of regexes to exclude warnings is not configurable for the JUnitChecker.")
+                         "Feature of regexes to include/exclude warnings is not configurable for the JUnitChecker.")
 
     def test_partial_xmlrunner_config_parsing(self):
         warnings = WarningsPlugin()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -100,12 +100,12 @@ class TestIntegration(TestCase):
 
     def test_sphinx_deprecation(self):
         retval = warnings_wrapper(['--sphinx', 'tests/sphinx_double_deprecation_warning.txt'])
-        self.assertEqual(2, retval)
-
-    def test_exclude_sphinx_deprecation(self):
-        retval = warnings_wrapper(['--sphinx', '--exclude-sphinx-deprecation', 'tests/sphinx_double_deprecation_warning.txt'])
         self.assertEqual(0, retval)
 
+    def test_exclude_sphinx_deprecation(self):
+        retval = warnings_wrapper(['--sphinx', '--include-sphinx-deprecation', 'tests/sphinx_double_deprecation_warning.txt'])
+        self.assertEqual(2, retval)
+
     def test_ignore_sphinx_deprecation_flag(self):
-        retval = warnings_wrapper(['--junit', '--exclude-sphinx-deprecation', 'tests/junit*.xml'])
+        retval = warnings_wrapper(['--junit', '--include-sphinx-deprecation', 'tests/junit*.xml'])
         self.assertEqual(self.junit_warning_cnt, retval)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -97,3 +97,15 @@ class TestIntegration(TestCase):
         with self.assertRaises(SystemExit) as ex:
             warnings_wrapper(['--config', 'tests/config_example.json', '--junit', 'tests/junit_single_fail.xml'])
         self.assertEqual(2, ex.exception.code)
+
+    def test_sphinx_deprecation(self):
+        retval = warnings_wrapper(['--sphinx', 'tests/sphinx_double_deprecation_warning.txt'])
+        self.assertEqual(2, retval)
+
+    def test_exclude_sphinx_deprecation(self):
+        retval = warnings_wrapper(['--sphinx', '--exclude-sphinx-deprecation', 'tests/sphinx_double_deprecation_warning.txt'])
+        self.assertEqual(0, retval)
+
+    def test_ignore_sphinx_deprecation_flag(self):
+        retval = warnings_wrapper(['--junit', '--exclude-sphinx-deprecation', 'tests/junit*.xml'])
+        self.assertEqual(self.junit_warning_cnt, retval)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -74,6 +74,18 @@ class TestSphinxWarnings(TestCase):
         self.assertEqual(self.warnings.return_count(), 1)
         self.assertEqual(fake_out.getvalue(), duterr1)
 
+    def test_deprecation_warning_excluded(self):
+        self.warnings.get_checker('sphinx').exclude_sphinx_deprecation()
+        duterr1 = "/usr/local/lib/python3.5/dist-packages/sphinx/application.py:402: RemovedInSphinx20Warning: "\
+            "app.info() is now deprecated. Use sphinx.util.logging instead. RemovedInSphinx20Warning\n"
+        dut = "This1 should not be treated as warning\n"
+        dut += duterr1
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            self.warnings.check(dut)
+        self.assertEqual(self.warnings.return_count(), 0)
+        verbose_print = "Excluded {warning!r}".format(warning=duterr1.rstrip("\n"))
+        self.assertIn(verbose_print, fake_out.getvalue(), verbose_print)
+
     def test_warning_no_docname(self):
         duterr1 = "WARNING: List item 'CL-UNDEFINED_CL_ITEM' in merge/pull request 138 is not defined as a checklist-item.\n"
         with patch('sys.stdout', new=StringIO()) as fake_out:

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -67,24 +67,23 @@ class TestSphinxWarnings(TestCase):
     def test_deprecation_warning(self):
         duterr1 = "/usr/local/lib/python3.5/dist-packages/sphinx/application.py:402: RemovedInSphinx20Warning: "\
             "app.info() is now deprecated. Use sphinx.util.logging instead. RemovedInSphinx20Warning\n"
-        dut = "This1 should not be treated as warning\n"
+        dut = "This should not be treated as warning2\n"
         dut += duterr1
         with patch('sys.stdout', new=StringIO()) as fake_out:
             self.warnings.check(dut)
-        self.assertEqual(self.warnings.return_count(), 1)
-        self.assertEqual(fake_out.getvalue(), duterr1)
+        self.assertEqual(self.warnings.return_count(), 0)
+        self.assertNotEqual(fake_out.getvalue(), duterr1)
 
-    def test_deprecation_warning_excluded(self):
-        self.warnings.get_checker('sphinx').exclude_sphinx_deprecation()
+    def test_deprecation_warning_included(self):
+        self.warnings.get_checker('sphinx').include_sphinx_deprecation()
         duterr1 = "/usr/local/lib/python3.5/dist-packages/sphinx/application.py:402: RemovedInSphinx20Warning: "\
             "app.info() is now deprecated. Use sphinx.util.logging instead. RemovedInSphinx20Warning\n"
         dut = "This1 should not be treated as warning\n"
         dut += duterr1
         with patch('sys.stdout', new=StringIO()) as fake_out:
             self.warnings.check(dut)
-        self.assertEqual(self.warnings.return_count(), 0)
-        verbose_print = "Excluded {warning!r}".format(warning=duterr1.rstrip("\n"))
-        self.assertIn(verbose_print, fake_out.getvalue(), verbose_print)
+        self.assertEqual(self.warnings.return_count(), 1)
+        self.assertEqual(fake_out.getvalue(), duterr1)
 
     def test_warning_no_docname(self):
         duterr1 = "WARNING: List item 'CL-UNDEFINED_CL_ITEM' in merge/pull request 138 is not defined as a checklist-item.\n"


### PR DESCRIPTION
The default behavior changes to no longer exclude Sphinx deprecation warnings. 
Using the new flag `--include-sphinx-deprecation` lets the sphinx checker count warnings that match regex `RemovedInSphinx\\d+Warning`.

This feature was suggested in #84 .