### PR TITLE
Add documentation badge and untrack version file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ graft tests
 # Include the readme file
 include README.rst
 include LICENSE
+exclude src/mlx/__warnings_version__.py
 
 include tox.ini .travis.yml .codeclimate.yml
 

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@
     :target: https://badge.fury.io/py/mlx.warnings
     :alt: Pypi packaged release
 
+.. image:: https://img.shields.io/badge/Documentation-published-brightgreen.png
+    :target: https://melexis.github.io/warnings-plugin/
+    :alt: Documentation
+
 .. image:: https://scan.coverity.com/projects/15266/badge.svg
     :target: https://scan.coverity.com/projects/melexis-warnings-plugin
     :alt: Coverity Scan Build Status

--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,6 @@
     :target: https://badge.fury.io/py/mlx.warnings
     :alt: Pypi packaged release
 
-.. image:: https://img.shields.io/badge/Documentation-published-brightgreen.png
-    :target: https://melexis.github.io/warnings-plugin/
-    :alt: Documentation
-
 .. image:: https://scan.coverity.com/projects/15266/badge.svg
     :target: https://scan.coverity.com/projects/melexis-warnings-plugin
     :alt: Coverity Scan Build Status

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     description='Command-line alternative for https://github.com/jenkinsci/warnings-plugin. '
                 'Useable with plugin-less CI systems.',
     long_description=open("README.rst").read(),
+    long_description_content_type='text/x-rst',
     zip_safe=False,
     license='Apache License, Version 2.0',
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,30 @@
-import io
 from glob import glob
-from os.path import basename, dirname, join, splitext
+from os.path import basename, splitext
 
 from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/warnings-plugin'
-
-
-def read(*names, **kwargs):
-    return io.open(
-        join(dirname(__file__), *names),
-        encoding=kwargs.get('encoding', 'utf8')
-    ).read()
-
 
 requires = ['junitparser>=1.0.0']
 
 setup(
     name='mlx.warnings',
     url=PROJECT_URL,
-    use_scm_version = {
+    use_scm_version={
         'write_to': 'src/mlx/__warnings_version__.py'
     },
     setup_requires=['setuptools_scm'],
     author='Bavo Van Achte',
     author_email='bavo.van.achte@gmail.com',
-    description='Command-line alternative for https://github.com/jenkinsci/warnings-plugin. Useable with plugin-less CI systems.',
+    description='Command-line alternative for https://github.com/jenkinsci/warnings-plugin. '
+                'Useable with plugin-less CI systems.',
     long_description=open("README.rst").read(),
     zip_safe=False,
     license='Apache License, Version 2.0',
     platforms='any',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    entry_points = {'console_scripts': ['mlx-warnings = mlx.warnings:main']},
+    entry_points={'console_scripts': ['mlx-warnings = mlx.warnings:main']},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
     install_requires=requires,
@@ -50,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         # 'Programming Language :: Python :: Implementation :: CPython',
         # 'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:
@@ -58,5 +51,5 @@ setup(
         # 'Programming Language :: Python :: Implementation :: Stackless',
         'Topic :: Utilities',
     ],
-    keywords = ['Gitlab CI', 'warnings', 'CI'],
+    keywords=['Gitlab CI', 'warnings', 'CI'],
 )

--- a/src/mlx/__warnings_version__.py
+++ b/src/mlx/__warnings_version__.py
@@ -1,0 +1,9 @@
+"""
+Dummy version file, this file will be overwritten during packaging
+and the version string will be automatically filled in with relevant
+content.
+The file is mainly here to allow users to distinct between installed
+and non installed imports of this module.
+"""
+
+version = 'this is a local copy'

--- a/src/mlx/__warnings_version__.py
+++ b/src/mlx/__warnings_version__.py
@@ -1,9 +1,0 @@
-"""
-Dummy version file, this file will be overwritten during packaging
-and the version string will be automatically filled in with relevant
-content.
-The file is mainly here to allow users to distinct between installed
-and non installed imports of this module.
-"""
-
-version = 'this is a local copy'

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -8,11 +8,12 @@ import json
 import subprocess
 import sys
 
+from pkg_resources import require
+
 from mlx.warnings_checker import CoverityChecker, DoxyChecker, JUnitChecker, SphinxChecker, XMLRunnerChecker
 
-from .__warnings_version__ import version as warnings_version
 
-__version__ = warnings_version
+__version__ = require('mlx.warnings')[0].version
 
 
 class WarningsPlugin:

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,6 @@ commands =
     check-manifest {toxinidir}
     flake8 src tests setup.py
 
-
 [testenv:coveralls]
 deps =
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -77,10 +77,12 @@ deps =
     readme-renderer
     flake8
     pygments
+    check-manifest
 skip_install = true
 commands =
     python setup.py sdist bdist
     twine check dist/*
+    check-manifest {toxinidir}
     flake8 src tests setup.py
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,13 +73,16 @@ commands =
 [testenv:check]
 deps =
     docutils
+    twine >= 1.12.0
     readme-renderer
     flake8
     pygments
 skip_install = true
 commands =
-    python setup.py check --strict --metadata --restructuredtext
+    python setup.py sdist bdist
+    twine check dist/*
     flake8 src tests setup.py
+
 
 [testenv:coveralls]
 deps =
@@ -109,5 +112,3 @@ commands =
 commands = coverage erase
 skip_install = true
 deps = coverage
-
-


### PR DESCRIPTION
I don't see a usecase for using the plugin without package installation. By not tracking the version file we can have a clean `git status` after local installation with `pip3 install -e .`.