### PR TITLE
Never return 0 on failure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,7 @@ command:
 Parse for XMLRunner errors
 --------------------------
 
-When you run [XMLRunner](https://github.com/xmlrunner/unittest-xml-reporting)
+When you run XMLRunner_,
 the errors are reported on the output, but they are not marked as failures in
 the test reports xml files. Since command exits as 1, we could not detect tests
 that just did not run (not failed). warnings-plugin now parses for the output
@@ -254,6 +254,7 @@ with command:
     python3 -m mlx.warnings --xmlrunner --command <commandforxmlrunner>
     python -m mlx.warnings --xmlrunner --command <commandforxmlrunner>
 
+.. _XMLRunner: https://github.com/xmlrunner/unittest-xml-reporting
 
 ----------------------------------
 Configuration file to pass options

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Help prints all currently supported commands and their usages.
 The command returns (shell $? variable):
 
 - value 0 when the number of counted warnings is within the supplied minimum and maximum limits: ok,
-- number of counted warnings (positive) when the counter number is not within those limit.
+- number of counted warnings (positive) when the counter number is not within those limit (1 in case of 0 counted warnings).
 
 ---------------------------
 Simple Command line options

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -145,9 +145,7 @@ class WarningsPlugin:
         '''
         if name is None:
             for checker in self.activated_checkers.values():
-                retval = checker.return_check_limits()
-                if retval:
-                    return retval
+                return checker.return_check_limits()
         else:
             return self.activated_checkers[name].return_check_limits()
 

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -145,7 +145,9 @@ class WarningsPlugin:
         '''
         if name is None:
             for checker in self.activated_checkers.values():
-                return checker.return_check_limits()
+                retval = checker.return_check_limits()
+                if retval:
+                    return retval
         else:
             return self.activated_checkers[name].return_check_limits()
 

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -141,7 +141,8 @@ class WarningsPlugin:
             name (WarningsChecker): The checker for which to check the return value
 
         Return:
-            int: 0 if the amount of warnings is within limits, 1 otherwise
+            int: 0 if the amount of warnings is within limits, the count of warnings otherwise
+                (or 1 in case of a count of 0 warnings)
         '''
         if name is None:
             for checker in self.activated_checkers.values():

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -126,20 +126,28 @@ class WarningsChecker:
             int: 0 if the amount of warnings is within limits, the count of warnings otherwise
                 (or 1 in case of a count of 0 warnings)
         '''
-        error_code = self.count
-        if self.warn_min == self.warn_max and self.count == self.warn_max:
+        if self.count > self.warn_max or self.count < self.warn_min:
+            return self._return_error_code()
+        elif self.warn_min == self.warn_max and self.count == self.warn_max:
             print("Number of warnings ({0.count}) is exactly as expected. Well done."
                   .format(self))
-            return 0
-        elif self.count > self.warn_max:
-            error_reason = "higher than the maximum limit"
-        elif self.count < self.warn_min:
-            error_reason = "lower than the minimum limit"
         else:
             print("Number of warnings ({0.count}) is between limits {0.warn_min} and {0.warn_max}. Well done."
                   .format(self))
-            return 0
-        # code below is only reached after failure; don't allow error code 0
+        return 0
+
+    def _return_error_code(self):
+        ''' Function for determining the return code and message on failure
+
+        Returns:
+            int: The count of warnings (or 1 in case of a count of 0 warnings)
+        '''
+        if self.count > self.warn_max:
+            error_reason = "higher than the maximum limit"
+        else:
+            error_reason = "lower than the minimum limit"
+
+        error_code = self.count
         if error_code == 0:
             error_code = 1
         print("Number of warnings ({0.count}) is {1} ({0.warn_min}). Returning error code {2}."

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -131,11 +131,11 @@ class WarningsChecker:
         elif self.count > self.warn_max:
             print("Number of warnings ({0.count}) is higher than the maximum limit ({0.warn_max}). "
                   "Returning error code 1.".format(self))
-            return self.count
+            return 1
         elif self.count < self.warn_min:
             print("Number of warnings ({0.count}) is lower than the minimum limit ({0.warn_min}). "
                   "Returning error code 1.".format(self))
-            return self.count
+            return 1
         else:
             print("Number of warnings ({0.count}) is between limits {0.warn_min} and {0.warn_max}. Well done."
                   .format(self))

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -74,8 +74,8 @@ class WarningsChecker:
             ValueError: Invalid argument (min limit higher than max limit)
         '''
         if self.warn_min > maximum:
-            raise ValueError("Invalid argument: mininum limit ({0.warn_min}) is higher than maximum limit "
-                             "({0.warn_max}). Cannot enter {value}". format(self, value=maximum))
+            raise ValueError("Invalid argument: minimum limit ({0.warn_min}) is higher than maximum limit "
+                             "({0.warn_max}). Cannot enter {value}.". format(self, value=maximum))
         else:
             self.warn_max = maximum
 
@@ -97,8 +97,8 @@ class WarningsChecker:
             ValueError: Invalid argument (min limit higher than max limit)
         '''
         if minimum > self.warn_max:
-            raise ValueError("Invalid argument: mininum limit ({0.warn_min}) is higher than maximum limit "
-                             "({0.warn_max}). Cannot enter {value}".format(self, value=minimum))
+            raise ValueError("Invalid argument: minimum limit ({0.warn_min}) is higher than maximum limit "
+                             "({0.warn_max}). Cannot enter {value}.".format(self, value=minimum))
         else:
             self.warn_min = minimum
 

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -131,11 +131,11 @@ class WarningsChecker:
         elif self.count > self.warn_max:
             print("Number of warnings ({0.count}) is higher than the maximum limit ({0.warn_max}). "
                   "Returning error code 1.".format(self))
-            return 1
+            return self.count
         elif self.count < self.warn_min:
             print("Number of warnings ({0.count}) is lower than the minimum limit ({0.warn_min}). "
                   "Returning error code 1.".format(self))
-            return 1
+            return self.count
         else:
             print("Number of warnings ({0.count}) is between limits {0.warn_min} and {0.warn_max}. Well done."
                   .format(self))

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -124,22 +124,27 @@ class WarningsChecker:
 
         Returns:
             int: 0 if the amount of warnings is within limits, the count of warnings otherwise
+                (or 1 in case of a count of 0 warnings)
         '''
+        error_code = self.count
         if self.warn_min == self.warn_max and self.count == self.warn_max:
             print("Number of warnings ({0.count}) is exactly as expected. Well done."
                   .format(self))
+            return 0
         elif self.count > self.warn_max:
-            print("Number of warnings ({0.count}) is higher than the maximum limit ({0.warn_max}). "
-                  "Returning error code 1.".format(self))
-            return self.count
+            error_reason = "higher than the maximum limit"
         elif self.count < self.warn_min:
-            print("Number of warnings ({0.count}) is lower than the minimum limit ({0.warn_min}). "
-                  "Returning error code 1.".format(self))
-            return self.count
+            error_reason = "lower than the minimum limit"
         else:
             print("Number of warnings ({0.count}) is between limits {0.warn_min} and {0.warn_max}. Well done."
                   .format(self))
-        return 0
+            return 0
+        # code below is only reached after failure; don't allow error code 0
+        if error_code == 0:
+            error_code = 1
+        print("Number of warnings ({0.count}) is {1} ({0.warn_min}). Returning error code {2}."
+              .format(self, error_reason, error_code))
+        return error_code
 
     def print_when_verbose(self, message):
         ''' Prints message only when verbose mode is enabled.

--- a/tests/sphinx_traceability_output.txt
+++ b/tests/sphinx_traceability_output.txt
@@ -1,0 +1,26 @@
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:79: WARNING: duplicating r005 trace r002
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:91: WARNING: duplicating r005
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:112: WARNING: item r007 attribute does not match defined attributes (asil=X)
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:109: WARNING: Error in "item" directive:
+unknown option: "non_existing_relation_or_attribute".
+
+.. item:: r009 Requirement with invalid relation kind or attribute
+    :non_existing_relation_or_attribute: r007
+
+    Ai caramba, this should report a warning as the relation kind or attribute does not exist.
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:205: WARNING: item ITEST_REP-CAPTION attribute does not match defined attributes (result=RUNNING)
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:270: WARNING: Found attribute description which is not defined in configuration (non_existing_attribute)
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:373: WARNING: Traceability: unknown relation for item-matrix: non_existing_relation
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:467: WARNING: Traceability: unknown attribute for item-attributes-matrix: non_existing_relation_or_attribute
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:473: WARNING: Traceability: unknown sorting attribute for item-attributes-matrix: non_existing_relation_or_attribute
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:513: WARNING: Traceability: unknown relation for item-2d-matrix: non_existing_relation
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:557: WARNING: Traceability: unknown relation for item-tree: non_existing_relation
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:565: WARNING: Traceability: unknown relation for item-tree: non_existing_relation
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:599: WARNING: sources argument required for item-link directive
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:605: WARNING: targets argument required for item-link directive
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:611: WARNING: type argument required for item-link directive
+WARNING: Item 'non_existing_requirement' has no reference to source document.
+WARNING: List item 'CL-UNDEFINED_CL_ITEM' in merge/pull request 138 is not defined as a checklist-item.
+C:\Users\jce\projects\git\sphinx-traceability-extension\doc\integration_test_report.rst:140: WARNING: Traceability: cannot link to 'non_existing_requirement', item is not defined
+c:\users\jce\projects\git\sphinx-traceability-extension\.tox\sphinx-latest\lib\site-packages\sphinx_rtd_theme\search.html:20: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
+  {{ super() }}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,6 +20,7 @@ class TestIntegration(TestCase):
             warnings_wrapper([])
         self.assertEqual(2, ex.exception.code)
 
+    min_ret_val_on_failure = 1
     junit_warning_cnt = 3
 
     def test_single_argument(self):
@@ -133,3 +134,11 @@ class TestIntegration(TestCase):
     def test_ignore_sphinx_deprecation_flag(self):
         retval = warnings_wrapper(['--junit', '--include-sphinx-deprecation', 'tests/junit*.xml'])
         self.assertEqual(self.junit_warning_cnt, retval)
+
+    def test_multiple_checkers_ret_val(self):
+        retval = warnings_wrapper(['--sphinx', '--junit', 'tests/junit*.xml'])
+        self.assertEqual(self.junit_warning_cnt, retval)
+
+    def test_non_zero_ret_val_on_failure(self):
+        retval = warnings_wrapper(['--sphinx', '--exact-warnings', '2', 'tests/junit*.xml'])
+        self.assertEqual(self.min_ret_val_on_failure, retval)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -142,3 +142,12 @@ class TestIntegration(TestCase):
     def test_non_zero_ret_val_on_failure(self):
         retval = warnings_wrapper(['--sphinx', '--exact-warnings', '2', 'tests/junit*.xml'])
         self.assertEqual(self.min_ret_val_on_failure, retval)
+
+    def test_various_sphinx_warnings(self):
+        """ Use the output log of the example documentation of mlx.traceability as input.
+
+        The input file contains 18 Sphinx warnings, but exactly 19 are required to pass.
+        The number of warnings (18) must be returned as return code.
+        """
+        retval = warnings_wrapper(['--sphinx', '--exact-warnings', '19', 'tests/sphinx_traceability_output.txt'])
+        self.assertEqual(18, retval)


### PR DESCRIPTION
Since tag 0.8.0 (https://github.com/melexis/warnings-plugin/commit/a32f4ebbccb811de9001af8a7f642d2cac96b228) there has been an unwanted behavior of the plugin where it can return 0 on failure. 
Let's return 1 instead of 0 if the number of warnings is 0, but we expected more than 0 warnings. 
For example, we don't want the plugin to return 0 when there are 0 warnings counted and we use `--minwarnings 1`.