### PR TITLE
Fix error message when maximum limit is exceeded

### DIFF
--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -143,14 +143,14 @@ class WarningsChecker:
             int: The count of warnings (or 1 in case of a count of 0 warnings)
         '''
         if self.count > self.warn_max:
-            error_reason = "higher than the maximum limit"
+            error_reason = "higher than the maximum limit ({0.warn_max})".format(self)
         else:
-            error_reason = "lower than the minimum limit"
+            error_reason = "lower than the minimum limit ({0.warn_min})".format(self)
 
         error_code = self.count
         if error_code == 0:
             error_code = 1
-        print("Number of warnings ({0.count}) is {1} ({0.warn_min}). Returning error code {2}."
+        print("Number of warnings ({0.count}) is {1}. Returning error code {2}."
               .format(self, error_reason, error_code))
         return error_code
 


### PR DESCRIPTION
Fixed printed explanation about error code when the number of warnings exceeds the maximum limit.

Example of error: when the minimum limit is set to 0 and the maximum limit set to 1, the plugin prints the following when it has counted 2 warnings:
`Number of warnings (2) is higher than the maximum limit (0). Returning error code 2.`

The correct explanation is:
`Number of warnings (2) is higher than the maximum limit (1). Returning error code 2.`

Bug created in https://github.com/melexis/warnings-plugin/pull/89 (version 1.3.0). 