### PR TITLE
Verify the presence of the robot suite name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,8 +267,8 @@ one specific test suite, you can use ``--name <<suite name>>``. If this suite
 name doesn't exist in the input file, an error is raised. The warning
 limits can be configured for multiple test suites individually by means of a
 `configuration file to pass options`_. If the setting ``"check_suite_names"``
-is missing or false, no error is raised when a suite name doesn't exist in the
-input file.
+is false, no error is raised when a suite name doesn't exist in the
+input file. When this setting is missing, the default value ``true`` is used.
 
 .. code-block:: bash
 
@@ -321,7 +321,7 @@ Configuration file is in JSON format with a simple structure.
         },
         "robot": {
             "enabled": false,
-            "check_suite_names": false,
+            "check_suite_names": true,
             "suites": [
                 {
                     "name": "My First Suite",

--- a/README.rst
+++ b/README.rst
@@ -263,9 +263,12 @@ When running `Robot Framework`_ tests with `--xunit report.xml`_ as an input
 argument, an xUnit compatible result file is generated. The warnings-plugin can
 parse this file and check the amount of failures. By default, the test results
 of all test suites in the file are taken into account. If you only care about
-one specific test suite, you can use ``--name <<suite name>>``. The warning
+one specific test suite, you can use ``--name <<suite name>>``. If this suite
+name doesn't exist in the input file, an error is raised. The warning
 limits can be configured for multiple test suites individually by means of a
-`configuration file to pass options`_.
+`configuration file to pass options`_. If the setting ``"check_suite_names"``
+is missing or false, no error is raised when a suite name doesn't exist in the
+input file.
 
 .. code-block:: bash
 
@@ -318,6 +321,7 @@ Configuration file is in JSON format with a simple structure.
         },
         "robot": {
             "enabled": false,
+            "check_suite_names": false,
             "suites": [
                 {
                     "name": "My First Suite",

--- a/src/mlx/robot_checker.py
+++ b/src/mlx/robot_checker.py
@@ -84,21 +84,25 @@ class RobotChecker(WarningsChecker):
 
     def parse_config(self, config):
         self.checkers = []
+        check_suite_name = config.get('check_suite_names', False)
         for suite_config in config['suites']:
-            checker = RobotSuiteChecker(suite_config['name'], verbose=self.verbose)
+            checker = RobotSuiteChecker(suite_config['name'], check_suite_name=check_suite_name,
+                                        verbose=self.verbose)
             checker.parse_config(suite_config)
             self.checkers.append(checker)
 
 
 class RobotSuiteChecker(JUnitChecker):
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, check_suite_name=False, **kwargs):
         ''' Constructor
 
         Args:
-            name: Name of the test suite to check the results of
+            name (str): Name of the test suite to check the results of
+            check_suite_name (bool): Whether to raise an error when no test in suite with given name is found
         '''
         super().__init__(**kwargs)
         self.name = name
+        self.check_suite_name = check_suite_name
 
     def return_count(self):
         ''' Getter function for the amount of warnings found

--- a/src/mlx/robot_checker.py
+++ b/src/mlx/robot_checker.py
@@ -84,7 +84,7 @@ class RobotChecker(WarningsChecker):
 
     def parse_config(self, config):
         self.checkers = []
-        check_suite_name = config.get('check_suite_names', False)
+        check_suite_name = config.get('check_suite_names', True)
         for suite_config in config['suites']:
             checker = RobotSuiteChecker(suite_config['name'], check_suite_name=check_suite_name,
                                         verbose=self.verbose)

--- a/src/mlx/warnings.py
+++ b/src/mlx/warnings.py
@@ -243,7 +243,10 @@ def warnings_wrapper(args):
             warnings.activate_checker_name('coverity')
         if args.robot:
             robot_checker = warnings.activate_checker_name('robot')
-            robot_checker.parse_config({'suites': [{'name': args.name, 'min': 0, 'max': 0}]})
+            robot_checker.parse_config({
+                'suites': [{'name': args.name, 'min': 0, 'max': 0}],
+                'check_suite_names': True,
+            })
         if args.exact_warnings:
             if args.maxwarnings | args.minwarnings:
                 print("expected-warnings cannot be provided with maxwarnings or minwarnings")

--- a/tests/test_in/config_example_robot.json
+++ b/tests/test_in/config_example_robot.json
@@ -26,6 +26,7 @@
     },
     "robot": {
         "enabled": true,
+        "check_suite_names": false,
         "suites": [
             {
                 "name": "Suite One",

--- a/tests/test_in/config_example_robot_invalid_suite.json
+++ b/tests/test_in/config_example_robot_invalid_suite.json
@@ -26,9 +26,10 @@
     },
     "robot": {
         "enabled": true,
+        "check_suite_names": true,
         "suites": [
             {
-                "name": "Suite One",
+                "name": "b4d su1te name",
                 "min": 0,
                 "max": 1
             },
@@ -41,11 +42,6 @@
                 "name": "Suite Two",
                 "min": 1,
                 "max": 2
-            },
-            {
-                "name": "b4d su1te name",
-                "min": 0,
-                "max": 0
             }
         ]
     }

--- a/tests/test_in/config_example_robot_invalid_suite.json
+++ b/tests/test_in/config_example_robot_invalid_suite.json
@@ -26,7 +26,6 @@
     },
     "robot": {
         "enabled": true,
-        "check_suite_names": true,
         "suites": [
             {
                 "name": "b4d su1te name",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -214,11 +214,8 @@ class TestIntegration(TestCase):
         self.maxDiff = None
         with patch('sys.stdout', new=StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm_err:
-                warnings_wrapper([
-                    '--config',
-                    'tests/test_in/config_example_robot_invalid_suite.json',
-                    'tests/test_in/robot_double_fail.xml',
-                ])
+                warnings_wrapper(['--config', 'tests/test_in/config_example_robot_invalid_suite.json',
+                                  'tests/test_in/robot_double_fail.xml'])
         stdout_log = fake_out.getvalue()
 
         self.assertEqual(
@@ -234,8 +231,8 @@ class TestIntegration(TestCase):
         self.maxDiff = None
         with patch('sys.stdout', new=StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm_err:
-                retval = warnings_wrapper(['--verbose', '--robot', '--name', 'Inv4lid Name',
-                                           'tests/test_in/robot_double_fail.xml'])
+                warnings_wrapper(['--verbose', '--robot', '--name', 'Inv4lid Name',
+                                  'tests/test_in/robot_double_fail.xml'])
         stdout_log = fake_out.getvalue()
 
         self.assertEqual(


### PR DESCRIPTION
Verify that the value of the `--name` input argument (only useful in combination with `--robot`) exists in the input file (xUnit XML file). If the given suite name does not exist, an error message is printed and error code -1 is returned.

Since this behavior may be undesired when using a `--config` file, this feature can be explicitly disabled by setting a new, optional setting called `"check_suite_names"` to `false` as shown below:

```
{
    "robot": {
        "enabled": true,
        "check_suite_names": false,
        "suites": [
            {
                "name": "My Suite Name",
                "min": 0,
                "max": 0
            }
    }
}
```
The default behavior is to raise an error when a suite name is not present in the input file, both for `--name` and `--config`.