### PR TITLE
Drop lxml as dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,10 +16,5 @@ Installation is as simple as:
     git clone https://github.com/melexis/warnings-plugin.git
     pip3 install -e warnings-plugin
 
-.. note::
-    mlx.warnings has a dependency to lxml, which may require your to install
-    additional libraries on Linux. If this is the case, please refer to the
-    `installation guide of lxml <https://lxml.de/installation.html>`_.
-
 So far we are not aware of any problems with installation of the plugin, but in
 case you have any please open an Issue.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/warnings-plugin'
 
-requires = ['junitparser>=1.0.0', 'lxml>=4.3.0']
+requires = ['junitparser>=1.0.0']
 
 setup(
     name='mlx.warnings',

--- a/src/mlx/junit_checker.py
+++ b/src/mlx/junit_checker.py
@@ -1,7 +1,7 @@
 import sys
+import xml.etree.ElementTree as ET
 
 from junitparser import Error, Failure, JUnitXml
-from lxml import etree as ET
 
 from mlx.warnings_checker import WarningsChecker
 


### PR DESCRIPTION
Drop lxml as dependency by using the built-in xml module instead. If there are errors while parsing an input XML file, e.g. due to invalid syntax, the description of the error may differ.