### PR TITLE
Support exclude feature for robot and junit checkers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,6 @@ Exclude Matches With Regexes
 
 In case you want a checker to exclude certain matches, you can configure
 one or more regular expressions in the configuration file on a per-checker basis.
-(Only sphinx, doxygen and xmlrunner checkers are currently supported by this feature.)
 If a pattern of a regex to exclude is found in a match of the checker's regex, the checker
 won't count that match. Add the regex(es) as a list of string values for the `exclude` key.
 An example configuration for the sphinx checker is given below:

--- a/src/mlx/junit_checker.py
+++ b/src/mlx/junit_checker.py
@@ -1,4 +1,3 @@
-import sys
 import xml.etree.ElementTree as ET
 
 from junitparser import Error, Failure, JUnitXml
@@ -28,9 +27,6 @@ class JUnitChecker(WarningsChecker):
                     amount_to_exclude += self._check_testcase(testcase)
             suites.update_statistics()
             self.count += suites.failures + suites.errors - amount_to_exclude
-            if not getattr(self, 'is_valid_suite_name', True) and getattr(self, 'check_suite_name', False):
-                print('ERROR: No suite with name {!r} found. Returning error code -1.'.format(self.name))
-                sys.exit(-1)
         except ET.ParseError as err:
             print(err)
 

--- a/src/mlx/junit_checker.py
+++ b/src/mlx/junit_checker.py
@@ -11,9 +11,6 @@ class JUnitChecker(WarningsChecker):
     def check(self, content):
         ''' Function for counting the number of JUnit failures in a specific text
 
-        If this class is subclassed, the test cases with a ``classname`` that does
-        not end with the ``name`` class attribute are ignored.
-
         Args:
             content (str): The content to parse
         '''

--- a/src/mlx/junit_checker.py
+++ b/src/mlx/junit_checker.py
@@ -18,7 +18,7 @@ class JUnitChecker(WarningsChecker):
             content (str): The content to parse
         '''
         try:
-            root_input = root_input = etree.fromstring(content.encode('utf-8'))
+            root_input = etree.fromstring(content.encode('utf-8'))
             testsuites_root = self.prepare_tree(root_input)
             suites = JUnitXml.fromelem(testsuites_root)
             amount_to_exclude = 0

--- a/src/mlx/regex_checker.py
+++ b/src/mlx/regex_checker.py
@@ -19,20 +19,6 @@ class RegexChecker(WarningsChecker):
     name = 'regex'
     pattern = None
 
-    def add_patterns(self, regexes, pattern_container):
-        ''' Adds regexes as patterns to the specified container
-
-        Args:
-            regexes (list[str]|None): List of regexes to add
-            pattern_container (list[re.Pattern]): Target storage container for patterns
-        '''
-        if regexes:
-            if not isinstance(regexes, list):
-                raise TypeError("Expected a list value for exclude key in configuration file; got {}"
-                                .format(regexes.__class__.__name__))
-            for regex in regexes:
-                pattern_container.append(re.compile(regex))
-
     def check(self, content):
         ''' Function for counting the number of warnings in a specific text
 
@@ -46,32 +32,6 @@ class RegexChecker(WarningsChecker):
                 continue
             self.count += 1
             self.print_when_verbose(match_string)
-
-    def _is_excluded(self, content):
-        ''' Checks if the specific text must be excluded based on the configured regexes for exclusion and inclusion.
-
-        Inclusion has priority over exclusion.
-
-        Args:
-            content (str): The content to parse
-
-        Returns:
-            bool: True for exclusion, False for inclusion
-        '''
-        matching_exclude_pattern = self._search_patterns(content, self.exclude_patterns)
-        if not self._search_patterns(content, self.include_patterns) and matching_exclude_pattern:
-            self.print_when_verbose("Excluded {!r} because of configured regex {!r}"
-                                    .format(content, matching_exclude_pattern))
-            return True
-        return False
-
-    @staticmethod
-    def _search_patterns(content, patterns):
-        ''' Returns the regex of the first pattern that matches specified content, None if nothing matches '''
-        for pattern in patterns:
-            if pattern.search(content):
-                return pattern.pattern
-        return None
 
 
 class CoverityChecker(RegexChecker):

--- a/src/mlx/robot_checker.py
+++ b/src/mlx/robot_checker.py
@@ -1,3 +1,5 @@
+import sys
+
 from junitparser import Error, Failure
 
 from mlx.junit_checker import JUnitChecker
@@ -135,3 +137,19 @@ class RobotSuiteChecker(JUnitChecker):
             self.is_valid_suite_name = True
             return super()._check_testcase(testcase)
         return int(self.name and isinstance(testcase.result, (Failure, Error)))
+
+    def check(self, content):
+        """ Function for counting the number of JUnit failures in a specific text
+
+        The test cases with a ``classname`` that does not end with the ``name`` class attribute are ignored.
+
+        Args:
+            content (str): The content to parse
+
+        Raises:
+            SystemExit: No suite with name ``self.name`` found. Returning error code -1.
+        """
+        super().check(content)
+        if not self.is_valid_suite_name and self.check_suite_name:
+            print('ERROR: No suite with name {!r} found. Returning error code -1.'.format(self.name))
+            sys.exit(-1)

--- a/src/mlx/robot_checker.py
+++ b/src/mlx/robot_checker.py
@@ -1,3 +1,5 @@
+from junitparser import Error, Failure
+
 from mlx.junit_checker import JUnitChecker
 from mlx.warnings_checker import WarningsChecker
 
@@ -103,6 +105,7 @@ class RobotSuiteChecker(JUnitChecker):
         super().__init__(**kwargs)
         self.name = name
         self.check_suite_name = check_suite_name
+        self.is_valid_suite_name = False
 
     def return_count(self):
         ''' Getter function for the amount of warnings found
@@ -115,3 +118,20 @@ class RobotSuiteChecker(JUnitChecker):
             msg = "Suite {!r}: {}".format(self.name, msg)
         print(msg)
         return self.count
+
+    def _check_testcase(self, testcase):
+        """ Handles the check of a test case element by checking if the result is a failure/error.
+
+        If it is to be excluded by a configured regex, or the test case does not belong to the suite, 1 is returned.
+        Otherwise, when in verbose mode, the suite name and test case name are printed.
+
+        Args:
+            testcase (junitparser.TestCase): Test case element to check for failure or error
+
+        Returns:
+            int: 1 if a failure/error is to be subtracted from the final count, 0 otherwise
+        """
+        if testcase.classname.endswith(self.name):
+            self.is_valid_suite_name = True
+            return super()._check_testcase(testcase)
+        return int(self.name and isinstance(testcase.result, (Failure, Error)))

--- a/src/mlx/warnings_checker.py
+++ b/src/mlx/warnings_checker.py
@@ -1,4 +1,5 @@
 import abc
+import re
 
 
 class WarningsChecker:
@@ -32,18 +33,18 @@ class WarningsChecker:
         return
 
     def add_patterns(self, regexes, pattern_container):
-        ''' Raises an Exception to explain that this feature is not available for the targeted checker
+        ''' Adds regexes as patterns to the specified container
 
         Args:
             regexes (list[str]|None): List of regexes to add
             pattern_container (list[re.Pattern]): Target storage container for patterns
-
-        Raises:
-            Exception: Feature of regexes to include/exclude warnings is only configurable for the RegexChecker classes
         '''
         if regexes:
-            raise Exception("Feature of regexes to include/exclude warnings is not configurable for the {}."
-                            .format(self.__class__.__name__))
+            if not isinstance(regexes, list):
+                raise TypeError("Expected a list value for exclude key in configuration file; got {}"
+                                .format(regexes.__class__.__name__))
+            for regex in regexes:
+                pattern_container.append(re.compile(regex))
 
     def set_maximum(self, maximum):
         ''' Setter function for the maximum amount of warnings
@@ -146,3 +147,29 @@ class WarningsChecker:
         self.set_maximum(int(config['max']))
         self.set_minimum(int(config['min']))
         self.add_patterns(config.get("exclude"), self.exclude_patterns)
+
+    def _is_excluded(self, content):
+        ''' Checks if the specific text must be excluded based on the configured regexes for exclusion and inclusion.
+
+        Inclusion has priority over exclusion.
+
+        Args:
+            content (str): The content to parse
+
+        Returns:
+            bool: True for exclusion, False for inclusion
+        '''
+        matching_exclude_pattern = self._search_patterns(content, self.exclude_patterns)
+        if not self._search_patterns(content, self.include_patterns) and matching_exclude_pattern:
+            self.print_when_verbose("Excluded {!r} because of configured regex {!r}"
+                                    .format(content, matching_exclude_pattern))
+            return True
+        return False
+
+    @staticmethod
+    def _search_patterns(content, patterns):
+        ''' Returns the regex of the first pattern that matches specified content, None if nothing matches '''
+        for pattern in patterns:
+            if pattern.search(content):
+                return pattern.pattern
+        return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,7 +133,7 @@ class TestConfig(TestCase):
             warnings.check(xmlfile.read())
         self.assertEqual(warnings.return_count(), 0)
 
-    def test_partial_junit_config_parsing_exclude_regex(self):
+    def test_partial_robot_config_parsing_exclude_regex(self):
         warnings = WarningsPlugin()
         tmpjson = {
             'robot': {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,6 +130,7 @@ class TestConfig(TestCase):
         }
         with self.assertRaises(TypeError) as c_m:
             warnings.config_parser_json(tmpjson)
+        self.assertEqual(str(c_m.exception), "Expected a list value for exclude key in configuration file; got str")
 
     def test_partial_junit_config_parsing_exclude_regex(self):
         warnings = WarningsPlugin()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,13 +125,40 @@ class TestConfig(TestCase):
                 'enabled': True,
                 'min': 0,
                 'max': 0,
-                "exclude": ["junit_checker_is_not_a_regex_checker"]
+                "exclude": ["able to trace this random failure msg"]
             }
         }
-        with self.assertRaises(Exception) as exc:
-            warnings.config_parser_json(tmpjson)
-        self.assertEqual(str(exc.exception),
-                         "Feature of regexes to include/exclude warnings is not configurable for the JUnitChecker.")
+        warnings.config_parser_json(tmpjson)
+        with open('tests/test_in/junit_single_fail.xml', 'r') as xmlfile:
+            warnings.check(xmlfile.read())
+        self.assertEqual(warnings.return_count(), 0)
+
+    def test_partial_junit_config_parsing_exclude_regex(self):
+        warnings = WarningsPlugin()
+        tmpjson = {
+            'robot': {
+                'enabled': True,
+                'suites': [
+                    {
+                        'name': 'Suite One',
+                        'min': 0,
+                        'max': 0,
+                        "exclude": ["does not exist"]  # excludes failure in suite
+                    },
+                    {
+                        'name': 'Suite Two',
+                        'min': 1,
+                        'max': 1,
+                        "exclude": ["does not exist"]  # no match for failure in suite
+                    }
+                ]
+            }
+        }
+        warnings.config_parser_json(tmpjson)
+        with open('tests/test_in/robot_double_fail.xml', 'r') as xmlfile:
+            warnings.check(xmlfile.read())
+        self.assertEqual(warnings.return_count(), 1)
+        self.assertEqual(warnings.return_check_limits(), 0)
 
     def test_partial_xmlrunner_config_parsing(self):
         warnings = WarningsPlugin()

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -65,3 +65,12 @@ class TestRobotWarnings(TestCase):
             self.warnings.check(xmlfile.read())
             count = self.warnings.return_count()
         self.assertEqual(count, 2)
+
+    def test_check_suite_name(self):
+        self.dut.checkers = [
+            RobotSuiteChecker('nonexistent_suite_name', check_suite_name=True),
+        ]
+        with open('tests/test_in/robot_double_fail.xml', 'r') as xmlfile:
+            with self.assertRaises(SystemExit) as c_m:
+                self.warnings.check(xmlfile.read())
+        self.assertEqual(c_m.exception.code, -1)


### PR DESCRIPTION
The feature that lets you exclude matches by configuring regexes is not yet supported for robot and junit checkers. See [readme](https://melexis.github.io/warnings-plugin/readme.html#exclude-matches-with-regexes). This PR adds support for this feature to those two checkers so that all checkers support this feature.

- [x] tested exclusion of verbose print when failure is excluded