### PR TITLE
Restrict max version of junitparser as version 2.0.0 is incompatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_URL = 'https://github.com/melexis/warnings-plugin'
 
-requires = ['junitparser>=1.0.0']
+requires = ['junitparser>=1.0.0,<2.*']
 
 setup(
     name='mlx.warnings',

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,6 @@ deps =
 deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-plantuml
-    junitparser>=1.0.0
 commands =
     sphinx-build {posargs:-E} -b doctest docs dist/docs
     sphinx-build {posargs:-E} -b html docs dist/docs


### PR DESCRIPTION
Changes in junitparser==2.0.0b1: https://github.com/weiwei/junitparser/commit/e1270ebd18e9a64d8468525f445b5dbbe9e38b53

Let's look to support this version in the future. For now, we should release this restriction asap. I opened https://github.com/melexis/warnings-plugin/issues/109 to follow up.