### PR TITLE
Clarify failure reason when absolute path cannot be converted for Code Quality report

### DIFF
--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -73,7 +73,11 @@ class RegexChecker(WarningsChecker):
             if name.startswith("path"):
                 path = Path(result)
                 if path.is_absolute():
-                    path = path.relative_to(Path.cwd())
+                    try:
+                        path = path.relative_to(Path.cwd())
+                    except ValueError as err:
+                        raise ValueError("Failed to convert abolute path to relative path for Code Quality report: "
+                                         f"{err}") from err
                 finding["location"]["path"] = str(path)
                 break
         for name, result in groups.items():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -325,11 +325,10 @@ class TestIntegration(TestCase):
                 '--config', 'tests/test_in/config_example.json',
                 'tests/test_in/mixed_warnings.txt',
             ])
-        self.assertEqual(
-            str(c_m.exception),
+        self.assertTrue(str(c_m.exception).startswith(
             "Failed to convert abolute path to relative path for Code Quality report: "
-            f"'/home/user/myproject/helper/SimpleTimer.h' is not in the subpath of '{Path.cwd()}' OR "
-            "one path is relative and the other is absolute.")
+            "'/home/user/myproject/helper/SimpleTimer.h'")
+        )
 
     def test_cq_description_format_missing_envvar(self):
         os.environ['FIRST_ENVVAR'] = 'envvar_value'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -316,6 +316,21 @@ class TestIntegration(TestCase):
         self.assertEqual(2, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file), '{} differs from {}'.format(out_file, ref_file))
 
+    def test_code_quality_abspath_failure(self):
+        filename = 'code_quality.json'
+        out_file = str(TEST_OUT_DIR / filename)
+        with self.assertRaises(ValueError) as c_m:
+            warnings_wrapper([
+                '--code-quality', out_file,
+                '--config', 'tests/test_in/config_example.json',
+                'tests/test_in/mixed_warnings.txt',
+            ])
+        self.assertEqual(
+            str(c_m.exception),
+            "Failed to convert abolute path to relative path for Code Quality report: "
+            f"'/home/user/myproject/helper/SimpleTimer.h' is not in the subpath of '{Path.cwd()}' OR "
+            "one path is relative and the other is absolute.")
+
     def test_cq_description_format_missing_envvar(self):
         os.environ['FIRST_ENVVAR'] = 'envvar_value'
         filename = 'code_quality_format.json'


### PR DESCRIPTION
The Code Quality report expects a relative path. If the warnings plugin is executed in a different location than the tools that generate the warnings/errors, it might not be able to convert the absolute path to a relative path and raise a `ValueError`.

https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool