### PR TITLE
Exclude Polyspace defects with status "Not a Defect" or "Justified"; Add substitution of env variables for min/max possible for Robot and Polyspace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -325,8 +325,10 @@ The value of that key is a list, which contains the name of the column to check 
 the value of that column to check together with ``min`` and ``max`` values.
 
 Note that all defects with one of the following statuses are excluded from the warnings and code quality report:
+
 - Justified
 - Not a Defect
+
 These statuses are used when you do not plan to fix your code in response to a result.
 The status "No Action Planned" is not listed because this is a default status if you do not explicitly specfify
 a status in you annotation.

--- a/README.rst
+++ b/README.rst
@@ -326,9 +326,10 @@ the value of that column to check together with ``min`` and ``max`` values.
 
 Note that all defects with one of the following statuses are excluded from the warnings and code quality report:
 - Justified
-- No Action Planned
 - Not a Defect
 These statuses are used when you do not plan to fix your code in response to a result.
+The status "No Action Planned" is not listed because this is a default status if you do not explicitly specfify
+a status in you annotation.
 More info can be found `on this help page`_.
 
 .. _`on this help page`: https://nl.mathworks.com/help/polyspace_access/ug/fix-or-comment-polyspace-results-web-browser.html

--- a/README.rst
+++ b/README.rst
@@ -324,6 +324,15 @@ For example, "run-time check" is the family of Code Prover and "defect" is the f
 The value of that key is a list, which contains the name of the column to check as a key and
 the value of that column to check together with ``min`` and ``max`` values.
 
+Note that all defects with one of the following statuses are excluded from the warnings and code quality report:
+- Justified
+- No Action Planned
+- Not a Defect
+These statuses are used when you do not plan to fix your code in response to a result.
+More info can be found `on this help page`_.
+
+.. _`on this help page`: https://nl.mathworks.com/help/polyspace_access/ug/fix-or-comment-polyspace-results-web-browser.html
+
 Example Checks
 ^^^^^^^^^^^^^^
 

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -258,13 +258,17 @@ class PolyspaceFamilyChecker(WarningsChecker):
             content (dict): The row of the TSV file
         '''
         if content[self.column_name].lower() == self.check_value:
-            tab_sep_string = "\t".join(content.values())
-            if not self._is_excluded(tab_sep_string):
-                self.count = self.count + 1
-                self.counted_warnings.append('family: {} -> {}: {}'.format(
-                    self.family_value,
-                    self.column_name,
-                    self.check_value
-                ))
-                if self.cq_enabled and content["color"].lower() != "green":
-                    self.add_code_quality_finding(content)
+            if content["status"].lower() in ["not a defect", "justified"]:
+                self.print_when_verbose("Excluded row {!r} because the status is 'Not a defect' or 'Justified'"
+                                    .format(content))
+            else:
+                tab_sep_string = "\t".join(content.values())
+                if not self._is_excluded(tab_sep_string):
+                    self.count = self.count + 1
+                    self.counted_warnings.append('family: {} -> {}: {}'.format(
+                        self.family_value,
+                        self.column_name,
+                        self.check_value
+                    ))
+                    if self.cq_enabled and content["color"].lower() != "green":
+                        self.add_code_quality_finding(content)

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -154,7 +154,7 @@ class PolyspaceChecker(WarningsChecker):
                         "'Family' column. These dicts need to consist 3 key-value pairs (Note: if 'min' or "
                         "'max' is not defined, it will get the default value of 0):\n"
                         "{\n    <column_name>: <value_to_check>,\n    min: <number>,\n    max: <number>\n};"
-                        f"got {column_name} as column_name and {check_value} as value_to_check"
+                        f"got {column_name!r} as column_name and {check_value!r} as value_to_check"
                     )
         for checker in self.checkers:
             checker.cq_enabled = self.cq_enabled

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -113,6 +113,20 @@ class PolyspaceChecker(WarningsChecker):
             count += checker.return_check_limits()
         return count
 
+    def config_parser(self, config, name):
+        ''' Parsing configuration dict extracted by previously opened JSON or YAML file
+
+        Args:
+            config (dict): Content of configuration file
+        '''
+        try:
+            from .warnings import substitute_envvar
+
+            substitute_envvar(config, {'min', 'max'})
+            print("Config parsing for {name} completed".format(name=name))
+        except KeyError as err:
+                print("Incomplete config. Missing: {key}".format(key=err))
+
     def parse_config(self, config):
         """Parsing configuration dict extracted by previously opened JSON or yaml/yml file
 
@@ -145,6 +159,7 @@ class PolyspaceChecker(WarningsChecker):
                     column_name = key.lower()
                     check_value = value.lower()
                     checker = PolyspaceFamilyChecker(family_value, column_name, check_value, verbose=self.verbose)
+                    self.config_parser(check, f"{family_value} ({column_name}:{check_value})")
                     checker.parse_config(check)
                     checker.cq_findings = self.cq_findings  # share object with sub-checkers
                     self.checkers.append(checker)

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -179,8 +179,6 @@ class PolyspaceFamilyChecker(WarningsChecker):
             family_value (str): The value to search for in the 'Family' column
             column_name (str): The name of the column
             check_value (str): The value to check in the column
-            minimum (int): The minimum amount the check_value can occur
-            maximum (int): The maximum amount the check_value can occur
         """
         super().__init__(**kwargs)
         self.family_value = family_value

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -125,7 +125,7 @@ class PolyspaceChecker(WarningsChecker):
             substitute_envvar(config, {'min', 'max'})
             print("Config parsing for {name} completed".format(name=name))
         except KeyError as err:
-                print("Incomplete config. Missing: {key}".format(key=err))
+            print("Incomplete config. Missing: {key}".format(key=err))
 
     def parse_config(self, config):
         """Parsing configuration dict extracted by previously opened JSON or yaml/yml file

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -243,7 +243,7 @@ class PolyspaceFamilyChecker(WarningsChecker):
         if "line" in row:
             finding["location"]["positions"]["begin"]["line"] = row["line"]
         if "col" in row:
-            finding["location"]["positions"]["begin"]["column"] = row["column"]
+            finding["location"]["positions"]["begin"]["column"] = row["col"]
         finding["description"] = description
         exclude = ("new", "status", "severity", "comment", "key")
         row_without_key = [value for key, value in row.items() if key not in exclude]

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -125,7 +125,7 @@ class PolyspaceChecker(WarningsChecker):
             substitute_envvar(config, {'min', 'max'})
             print("Config parsing for {name} completed".format(name=name))
         except KeyError as err:
-            print("Incomplete config. Missing: {key}".format(key=err))
+                print("Incomplete config. Missing: {key}".format(key=err))
 
     def parse_config(self, config):
         """Parsing configuration dict extracted by previously opened JSON or yaml/yml file

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -243,7 +243,7 @@ class PolyspaceFamilyChecker(WarningsChecker):
         if "line" in row:
             finding["location"]["positions"]["begin"]["line"] = row["line"]
         if "col" in row:
-            finding["location"]["positions"]["begin"]["column"] = row["line"]
+            finding["location"]["positions"]["begin"]["column"] = row["column"]
         finding["description"] = description
         exclude = ("new", "status", "severity", "comment", "key")
         row_without_key = [value for key, value in row.items() if key not in exclude]

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -260,7 +260,7 @@ class PolyspaceFamilyChecker(WarningsChecker):
         if content[self.column_name].lower() == self.check_value:
             if content["status"].lower() in ["not a defect", "justified"]:
                 self.print_when_verbose("Excluded row {!r} because the status is 'Not a defect' or 'Justified'"
-                                    .format(content))
+                                        .format(content))
             else:
                 tab_sep_string = "\t".join(content.values())
                 if not self._is_excluded(tab_sep_string):

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -113,20 +113,6 @@ class PolyspaceChecker(WarningsChecker):
             count += checker.return_check_limits()
         return count
 
-    def config_parser(self, config, name):
-        ''' Parsing configuration dict extracted by previously opened JSON or YAML file
-
-        Args:
-            config (dict): Content of configuration file
-        '''
-        try:
-            from .warnings import substitute_envvar
-
-            substitute_envvar(config, {'min', 'max'})
-            print("Config parsing for {name} completed".format(name=name))
-        except KeyError as err:
-                print("Incomplete config. Missing: {key}".format(key=err))
-
     def parse_config(self, config):
         """Parsing configuration dict extracted by previously opened JSON or yaml/yml file
 
@@ -159,7 +145,6 @@ class PolyspaceChecker(WarningsChecker):
                     column_name = key.lower()
                     check_value = value.lower()
                     checker = PolyspaceFamilyChecker(family_value, column_name, check_value, verbose=self.verbose)
-                    self.config_parser(check, f"{family_value} ({column_name}:{check_value})")
                     checker.parse_config(check)
                     checker.cq_findings = self.cq_findings  # share object with sub-checkers
                     self.checkers.append(checker)

--- a/src/mlx/warnings/robot_checker.py
+++ b/src/mlx/warnings/robot_checker.py
@@ -88,12 +88,27 @@ class RobotChecker(WarningsChecker):
             count += checker.return_check_limits()
         return count
 
+    def config_parser(self, config, name):
+        ''' Parsing configuration dict extracted by previously opened JSON or YAML file
+
+        Args:
+            config (dict): Content of configuration file
+        '''
+        try:
+            from .warnings import substitute_envvar
+
+            substitute_envvar(config, {'min', 'max'})
+            print("Config parsing for suite {name!r} completed".format(name=name))
+        except KeyError as err:
+                print("Incomplete config. Missing: {key}".format(key=err))
+
     def parse_config(self, config):
         self.checkers = []
         check_suite_name = config.get('check_suite_names', True)
         for suite_config in config['suites']:
             checker = RobotSuiteChecker(suite_config['name'], check_suite_name=check_suite_name,
                                         verbose=self.verbose)
+            self.config_parser(suite_config, suite_config['name'])
             checker.parse_config(suite_config)
             self.checkers.append(checker)
 

--- a/src/mlx/warnings/robot_checker.py
+++ b/src/mlx/warnings/robot_checker.py
@@ -88,27 +88,12 @@ class RobotChecker(WarningsChecker):
             count += checker.return_check_limits()
         return count
 
-    def config_parser(self, config, name):
-        ''' Parsing configuration dict extracted by previously opened JSON or YAML file
-
-        Args:
-            config (dict): Content of configuration file
-        '''
-        try:
-            from .warnings import substitute_envvar
-
-            substitute_envvar(config, {'min', 'max'})
-            print("Config parsing for suite {name!r} completed".format(name=name))
-        except KeyError as err:
-                print("Incomplete config. Missing: {key}".format(key=err))
-
     def parse_config(self, config):
         self.checkers = []
         check_suite_name = config.get('check_suite_names', True)
         for suite_config in config['suites']:
             checker = RobotSuiteChecker(suite_config['name'], check_suite_name=check_suite_name,
                                         verbose=self.verbose)
-            self.config_parser(suite_config, suite_config['name'])
             checker.parse_config(suite_config)
             self.checkers.append(checker)
 

--- a/src/mlx/warnings/robot_checker.py
+++ b/src/mlx/warnings/robot_checker.py
@@ -100,7 +100,7 @@ class RobotChecker(WarningsChecker):
             substitute_envvar(config, {'min', 'max'})
             print("Config parsing for suite {name!r} completed".format(name=name))
         except KeyError as err:
-            print("Incomplete config. Missing: {key}".format(key=err))
+                print("Incomplete config. Missing: {key}".format(key=err))
 
     def parse_config(self, config):
         self.checkers = []

--- a/src/mlx/warnings/robot_checker.py
+++ b/src/mlx/warnings/robot_checker.py
@@ -100,7 +100,7 @@ class RobotChecker(WarningsChecker):
             substitute_envvar(config, {'min', 'max'})
             print("Config parsing for suite {name!r} completed".format(name=name))
         except KeyError as err:
-                print("Incomplete config. Missing: {key}".format(key=err))
+            print("Incomplete config. Missing: {key}".format(key=err))
 
     def parse_config(self, config):
         self.checkers = []

--- a/src/mlx/warnings/warnings.py
+++ b/src/mlx/warnings/warnings.py
@@ -21,7 +21,6 @@ from .polyspace_checker import PolyspaceChecker
 __version__ = distribution('mlx.warnings').version
 
 
-
 class WarningsPlugin:
 
     def __init__(self, verbose=False, config_file=None, cq_enabled=False):

--- a/src/mlx/warnings/warnings.py
+++ b/src/mlx/warnings/warnings.py
@@ -5,12 +5,10 @@ import argparse
 import errno
 import glob
 import json
-import os
 import subprocess
 import sys
 from importlib.metadata import distribution
 from pathlib import Path
-from string import Template
 
 from ruamel.yaml import YAML
 
@@ -22,25 +20,6 @@ from .polyspace_checker import PolyspaceChecker
 
 __version__ = distribution('mlx.warnings').version
 
-
-def substitute_envvar(checker_config, keys):
-    """Modifies configuration for checker in-place, resolving any environment variables for ``keys``
-
-    Args:
-        checker_config (dict): Configuration for a specific WarningsChecker
-        keys (set): Set of keys to process the value of
-
-    Raises:
-        WarningsConfigError: Failed to find an environment variable
-    """
-    for key in keys:
-        if key in checker_config and isinstance(checker_config[key], str):
-            template_obj = Template(checker_config[key])
-            try:
-                checker_config[key] = template_obj.substitute(os.environ)
-            except KeyError as err:
-                raise WarningsConfigError(f"Failed to find environment variable {err} for configuration value {key!r}")\
-                    from None
 
 
 class WarningsPlugin:
@@ -229,7 +208,6 @@ class WarningsPlugin:
             try:
                 checker_config = config[checker.name]
                 if bool(checker_config['enabled']):
-                    substitute_envvar(checker_config, {'min', 'max'})
                     self.activate_checker(checker)
                     checker.parse_config(checker_config)
                     print("Config parsing for {name} completed".format(name=checker.name))

--- a/tests/test_in/config_example_polyspace_exclude.json
+++ b/tests/test_in/config_example_polyspace_exclude.json
@@ -36,8 +36,8 @@
         "run-time check": [
             {
                 "color": "red",
-                "min": 0,
-                "max": 0
+                "min": "$MIN_POLY_WARNINGS",
+                "max": "${MAX_POLY_WARNINGS}"
             },
             {
                 "color": "orange",

--- a/tests/test_in/config_example_polyspace_exclude.json
+++ b/tests/test_in/config_example_polyspace_exclude.json
@@ -36,8 +36,8 @@
         "run-time check": [
             {
                 "color": "red",
-                "min": "$MIN_POLY_WARNINGS",
-                "max": "${MAX_POLY_WARNINGS}"
+                "min": 0,
+                "max": 0
             },
             {
                 "color": "orange",

--- a/tests/test_in/config_example_robot.json
+++ b/tests/test_in/config_example_robot.json
@@ -45,8 +45,8 @@
             },
             {
                 "name": "b4d su1te name",
-                "min": 0,
-                "max": 0
+                "min": "$MIN_ROBOT_WARNINGS",
+                "max": "${MAX_ROBOT_WARNINGS}"
             }
         ]
     },

--- a/tests/test_in/config_example_robot.json
+++ b/tests/test_in/config_example_robot.json
@@ -45,8 +45,8 @@
             },
             {
                 "name": "b4d su1te name",
-                "min": "$MIN_ROBOT_WARNINGS",
-                "max": "${MAX_ROBOT_WARNINGS}"
+                "min": 0,
+                "max": 0
             }
         ]
     },

--- a/tests/test_in/polyspace.tsv
+++ b/tests/test_in/polyspace.tsv
@@ -25,20 +25,20 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 22036	Run-time Check	Numerical	Green	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		C4992326D32B4698C491	6	4
 22065	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		C49953E693A45698C489	5	5
 22035	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		C499232693A45698C491	5	6
-21989	Run-time Check	Numerical	Green	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		C4997327D32B4698C881	6	7
+21989	Run-time Check	Numerical	Green	no	Overflow		dummy_function()	dummy_file_name.c	Not a defect	Unset		C4997327D32B4698C881	6	7
 19928	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		62C8B1F4CA9126336A	6	8
-19962	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		62D8A9F4CA91263472	7	9
+19962	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Not a defect	Unset		62D8A9F4CA91263472	7	9
 19526	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C899F4CA9126316A	7	10
 19424	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Unreviewed	Unset		62E489F4CA91263262	6	11
-19429	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Unreviewed	Unset		62E4A1F4CA91263162	6	2
+19429	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Justified	Unset		62E4A1F4CA91263162	6	2
 19442	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Unreviewed	Unset		62C091F4CA91263170	7	3
-19450	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Unreviewed	Unset		62C091F4CA91263170	7	3
+19450	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Justified	Unset		62C091F4CA91263170	7	3
 19375	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C089F4CA9126326C	8	4
 19378	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C091F4CA9126316E	8	5
 19377	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C091F4CA9126336A	7	6
 19357	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8A9F4CA91263368	7	7
 19352	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8A9F4CA91263760	8	8
-19351	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8A9F4CA91263862	8	9
+19351	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Justified	Unset		66C8A9F4CA91263862	8	9
 19355	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8A9F4CA91263962	9	10
 19354	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9153E995234C62C091	9	11
 19358	Run-time Check	Numerical	Orange	no	Overflow	Origin: Path related issue	dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9153E995234C62C0C1	8	3
@@ -46,7 +46,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 19349	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8C1F4CA91263262	9	5
 19345	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8C1F4CA91263470	9	6
 19344	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8C1F4CA91263572	10	7
-19339	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66CC91F4CA91263464	10	8
+19339	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Not a defect	Unset		66CC91F4CA91263464	10	8
 19338	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66CC91F4CA91263468	9	9
 19336	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66CC91F4CA91263970	9	10
 19335	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9923E995234C62C0C9	10	11

--- a/tests/test_in/polyspace_code_quality.json
+++ b/tests/test_in/polyspace_code_quality.json
@@ -6,7 +6,7 @@
             "positions": {
                 "begin": {
                     "line": "6",
-                    "column": "6"
+                    "column": "8"
                 }
             }
         },
@@ -20,7 +20,7 @@
             "positions": {
                 "begin": {
                     "line": "7",
-                    "column": "7"
+                    "column": "10"
                 }
             }
         },
@@ -34,7 +34,7 @@
             "positions": {
                 "begin": {
                     "line": "6",
-                    "column": "6"
+                    "column": "11"
                 }
             }
         },
@@ -48,7 +48,7 @@
             "positions": {
                 "begin": {
                     "line": "7",
-                    "column": "7"
+                    "column": "3"
                 }
             }
         },
@@ -62,7 +62,7 @@
             "positions": {
                 "begin": {
                     "line": "8",
-                    "column": "8"
+                    "column": "4"
                 }
             }
         },
@@ -76,7 +76,7 @@
             "positions": {
                 "begin": {
                     "line": "8",
-                    "column": "8"
+                    "column": "5"
                 }
             }
         },
@@ -90,7 +90,7 @@
             "positions": {
                 "begin": {
                     "line": "7",
-                    "column": "7"
+                    "column": "6"
                 }
             }
         },
@@ -132,7 +132,7 @@
             "positions": {
                 "begin": {
                     "line": "9",
-                    "column": "9"
+                    "column": "10"
                 }
             }
         },
@@ -146,7 +146,7 @@
             "positions": {
                 "begin": {
                     "line": "9",
-                    "column": "9"
+                    "column": "11"
                 }
             }
         },
@@ -160,7 +160,7 @@
             "positions": {
                 "begin": {
                     "line": "8",
-                    "column": "8"
+                    "column": "3"
                 }
             }
         },
@@ -174,7 +174,7 @@
             "positions": {
                 "begin": {
                     "line": "8",
-                    "column": "8"
+                    "column": "4"
                 }
             }
         },
@@ -188,7 +188,7 @@
             "positions": {
                 "begin": {
                     "line": "9",
-                    "column": "9"
+                    "column": "5"
                 }
             }
         },
@@ -202,7 +202,7 @@
             "positions": {
                 "begin": {
                     "line": "9",
-                    "column": "9"
+                    "column": "6"
                 }
             }
         },
@@ -216,7 +216,7 @@
             "positions": {
                 "begin": {
                     "line": "10",
-                    "column": "10"
+                    "column": "7"
                 }
             }
         },
@@ -244,7 +244,7 @@
             "positions": {
                 "begin": {
                     "line": "9",
-                    "column": "9"
+                    "column": "10"
                 }
             }
         },
@@ -258,7 +258,7 @@
             "positions": {
                 "begin": {
                     "line": "10",
-                    "column": "10"
+                    "column": "11"
                 }
             }
         },
@@ -272,7 +272,7 @@
             "positions": {
                 "begin": {
                     "line": "15",
-                    "column": "15"
+                    "column": "5"
                 }
             }
         },
@@ -286,7 +286,7 @@
             "positions": {
                 "begin": {
                     "line": "15",
-                    "column": "15"
+                    "column": "6"
                 }
             }
         },
@@ -300,7 +300,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "7"
                 }
             }
         },
@@ -314,7 +314,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "8"
                 }
             }
         },
@@ -328,7 +328,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "9"
                 }
             }
         },
@@ -342,7 +342,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "10"
                 }
             }
         },
@@ -356,7 +356,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "11"
                 }
             }
         },
@@ -370,7 +370,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "12"
                 }
             }
         },
@@ -384,7 +384,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "13"
                 }
             }
         },
@@ -398,7 +398,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "14"
                 }
             }
         },
@@ -412,7 +412,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "5"
                 }
             }
         },
@@ -426,7 +426,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "6"
                 }
             }
         },
@@ -440,7 +440,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "6"
                 }
             }
         },
@@ -454,7 +454,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "7"
                 }
             }
         },
@@ -468,7 +468,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "8"
                 }
             }
         },
@@ -482,7 +482,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "9"
                 }
             }
         },
@@ -496,7 +496,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "10"
                 }
             }
         },
@@ -510,7 +510,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "11"
                 }
             }
         },
@@ -524,7 +524,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "12"
                 }
             }
         },
@@ -538,7 +538,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "13"
                 }
             }
         },
@@ -552,7 +552,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "14"
                 }
             }
         },
@@ -566,7 +566,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "6"
                 }
             }
         },
@@ -580,7 +580,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "7"
                 }
             }
         },
@@ -594,7 +594,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "8"
                 }
             }
         },
@@ -608,7 +608,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "9"
                 }
             }
         },
@@ -622,7 +622,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "10"
                 }
             }
         },
@@ -636,7 +636,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "11"
                 }
             }
         },
@@ -650,7 +650,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "12"
                 }
             }
         },
@@ -664,7 +664,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "13"
                 }
             }
         },
@@ -678,7 +678,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "14"
                 }
             }
         },
@@ -692,7 +692,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "15"
                 }
             }
         },
@@ -706,7 +706,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "6"
                 }
             }
         },
@@ -720,7 +720,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "7"
                 }
             }
         },
@@ -734,7 +734,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "7"
                 }
             }
         },
@@ -748,7 +748,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "8"
                 }
             }
         },
@@ -762,7 +762,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "9"
                 }
             }
         },
@@ -776,7 +776,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "10"
                 }
             }
         },
@@ -790,7 +790,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "11"
                 }
             }
         },
@@ -804,7 +804,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "12"
                 }
             }
         },
@@ -818,7 +818,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "13"
                 }
             }
         },
@@ -832,7 +832,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "14"
                 }
             }
         },
@@ -846,7 +846,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "15"
                 }
             }
         },
@@ -860,7 +860,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "7"
                 }
             }
         },
@@ -874,7 +874,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "8"
                 }
             }
         },
@@ -888,7 +888,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "9"
                 }
             }
         },
@@ -902,7 +902,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "10"
                 }
             }
         },
@@ -916,7 +916,7 @@
             "positions": {
                 "begin": {
                     "line": "24",
-                    "column": "24"
+                    "column": "11"
                 }
             }
         },
@@ -930,7 +930,7 @@
             "positions": {
                 "begin": {
                     "line": "24",
-                    "column": "24"
+                    "column": "12"
                 }
             }
         },
@@ -944,7 +944,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "13"
                 }
             }
         },
@@ -958,7 +958,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "14"
                 }
             }
         },
@@ -972,7 +972,7 @@
             "positions": {
                 "begin": {
                     "line": "24",
-                    "column": "24"
+                    "column": "15"
                 }
             }
         },
@@ -986,7 +986,7 @@
             "positions": {
                 "begin": {
                     "line": "24",
-                    "column": "24"
+                    "column": "16"
                 }
             }
         },
@@ -1000,7 +1000,7 @@
             "positions": {
                 "begin": {
                     "line": "25",
-                    "column": "25"
+                    "column": "7"
                 }
             }
         },
@@ -1014,7 +1014,7 @@
             "positions": {
                 "begin": {
                     "line": "25",
-                    "column": "25"
+                    "column": "8"
                 }
             }
         },
@@ -1028,7 +1028,7 @@
             "positions": {
                 "begin": {
                     "line": "24",
-                    "column": "24"
+                    "column": "8"
                 }
             }
         },

--- a/tests/test_in/polyspace_code_quality.json
+++ b/tests/test_in/polyspace_code_quality.json
@@ -25,20 +25,6 @@
             }
         },
         "description": "Polyspace: Overflow",
-        "fingerprint": "29a5e4588709eb7271a30605d4fd3bd3"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.c",
-            "positions": {
-                "begin": {
-                    "line": "7",
-                    "column": "7"
-                }
-            }
-        },
-        "description": "Polyspace: Overflow",
         "fingerprint": "1e18bf5563037b1193f838617b4be1af"
     },
     {
@@ -61,20 +47,6 @@
             "path": "dummy_file_name.h",
             "positions": {
                 "begin": {
-                    "line": "6",
-                    "column": "6"
-                }
-            }
-        },
-        "description": "Polyspace: Overflow",
-        "fingerprint": "cabd96c885bd6d9ed3fe867b227e8128"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.h",
-            "positions": {
-                "begin": {
                     "line": "7",
                     "column": "7"
                 }
@@ -82,20 +54,6 @@
         },
         "description": "Polyspace: Overflow",
         "fingerprint": "1961351c7f028d02202f915a6d36c658"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.h",
-            "positions": {
-                "begin": {
-                    "line": "7",
-                    "column": "7"
-                }
-            }
-        },
-        "description": "Polyspace: Overflow",
-        "fingerprint": "fb6455c4794157cb304be4106e115e35"
     },
     {
         "severity": "major",
@@ -166,20 +124,6 @@
         },
         "description": "Polyspace: Overflow",
         "fingerprint": "e790d2d7f4e8fc2fb244ab0f74beca64"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.c",
-            "positions": {
-                "begin": {
-                    "line": "8",
-                    "column": "8"
-                }
-            }
-        },
-        "description": "Polyspace: Overflow",
-        "fingerprint": "2848e52a5925a6e7d35aacf6cbf5afed"
     },
     {
         "severity": "major",
@@ -278,20 +222,6 @@
         },
         "description": "Polyspace: Overflow",
         "fingerprint": "591d152475bd60b07e0e7f00ec000229"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.c",
-            "positions": {
-                "begin": {
-                    "line": "10",
-                    "column": "10"
-                }
-            }
-        },
-        "description": "Polyspace: Overflow",
-        "fingerprint": "c1886be8c04e07b85f86f2571f0fa03d"
     },
     {
         "severity": "major",

--- a/tests/test_in/polyspace_code_quality_exclude.json
+++ b/tests/test_in/polyspace_code_quality_exclude.json
@@ -6,7 +6,7 @@
             "positions": {
                 "begin": {
                     "line": "6",
-                    "column": "6"
+                    "column": "11"
                 }
             }
         },
@@ -20,7 +20,7 @@
             "positions": {
                 "begin": {
                     "line": "7",
-                    "column": "7"
+                    "column": "3"
                 }
             }
         },
@@ -34,7 +34,7 @@
             "positions": {
                 "begin": {
                     "line": "15",
-                    "column": "15"
+                    "column": "5"
                 }
             }
         },
@@ -48,7 +48,7 @@
             "positions": {
                 "begin": {
                     "line": "15",
-                    "column": "15"
+                    "column": "6"
                 }
             }
         },
@@ -62,7 +62,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "7"
                 }
             }
         },
@@ -76,7 +76,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "8"
                 }
             }
         },
@@ -90,7 +90,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "9"
                 }
             }
         },
@@ -104,7 +104,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "10"
                 }
             }
         },
@@ -118,7 +118,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "11"
                 }
             }
         },
@@ -132,7 +132,7 @@
             "positions": {
                 "begin": {
                     "line": "16",
-                    "column": "16"
+                    "column": "12"
                 }
             }
         },
@@ -146,7 +146,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "13"
                 }
             }
         },
@@ -160,7 +160,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "14"
                 }
             }
         },
@@ -174,7 +174,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "5"
                 }
             }
         },
@@ -188,7 +188,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "6"
                 }
             }
         },
@@ -202,7 +202,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "6"
                 }
             }
         },
@@ -216,7 +216,7 @@
             "positions": {
                 "begin": {
                     "line": "17",
-                    "column": "17"
+                    "column": "7"
                 }
             }
         },
@@ -230,7 +230,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "8"
                 }
             }
         },
@@ -244,7 +244,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "9"
                 }
             }
         },
@@ -258,7 +258,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "10"
                 }
             }
         },
@@ -272,7 +272,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "11"
                 }
             }
         },
@@ -286,7 +286,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "12"
                 }
             }
         },
@@ -300,7 +300,7 @@
             "positions": {
                 "begin": {
                     "line": "18",
-                    "column": "18"
+                    "column": "13"
                 }
             }
         },
@@ -314,7 +314,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "14"
                 }
             }
         },
@@ -328,7 +328,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "6"
                 }
             }
         },
@@ -342,7 +342,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "7"
                 }
             }
         },
@@ -356,7 +356,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "8"
                 }
             }
         },
@@ -370,7 +370,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "9"
                 }
             }
         },
@@ -384,7 +384,7 @@
             "positions": {
                 "begin": {
                     "line": "19",
-                    "column": "19"
+                    "column": "10"
                 }
             }
         },
@@ -398,7 +398,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "11"
                 }
             }
         },
@@ -412,7 +412,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "12"
                 }
             }
         },
@@ -426,7 +426,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "13"
                 }
             }
         },
@@ -440,7 +440,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "14"
                 }
             }
         },
@@ -454,7 +454,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "15"
                 }
             }
         },
@@ -468,7 +468,7 @@
             "positions": {
                 "begin": {
                     "line": "20",
-                    "column": "20"
+                    "column": "6"
                 }
             }
         },
@@ -482,7 +482,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "7"
                 }
             }
         },
@@ -496,7 +496,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "7"
                 }
             }
         },
@@ -510,7 +510,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "8"
                 }
             }
         },
@@ -524,7 +524,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "9"
                 }
             }
         },
@@ -538,7 +538,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "10"
                 }
             }
         },
@@ -552,7 +552,7 @@
             "positions": {
                 "begin": {
                     "line": "21",
-                    "column": "21"
+                    "column": "11"
                 }
             }
         },
@@ -566,7 +566,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "12"
                 }
             }
         },
@@ -580,7 +580,7 @@
             "positions": {
                 "begin": {
                     "line": "22",
-                    "column": "22"
+                    "column": "13"
                 }
             }
         },
@@ -594,7 +594,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "14"
                 }
             }
         },
@@ -608,7 +608,7 @@
             "positions": {
                 "begin": {
                     "line": "23",
-                    "column": "23"
+                    "column": "15"
                 }
             }
         },

--- a/tests/test_in/polyspace_code_quality_exclude.json
+++ b/tests/test_in/polyspace_code_quality_exclude.json
@@ -19,20 +19,6 @@
             "path": "dummy_file_name.h",
             "positions": {
                 "begin": {
-                    "line": "6",
-                    "column": "6"
-                }
-            }
-        },
-        "description": "12345 Run-time Check: Overflow",
-        "fingerprint": "cabd96c885bd6d9ed3fe867b227e8128"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.h",
-            "positions": {
-                "begin": {
                     "line": "7",
                     "column": "7"
                 }
@@ -40,20 +26,6 @@
         },
         "description": "12345 Run-time Check: Overflow",
         "fingerprint": "1961351c7f028d02202f915a6d36c658"
-    },
-    {
-        "severity": "major",
-        "location": {
-            "path": "dummy_file_name.h",
-            "positions": {
-                "begin": {
-                    "line": "7",
-                    "column": "7"
-                }
-            }
-        },
-        "description": "12345 Run-time Check: Overflow",
-        "fingerprint": "fb6455c4794157cb304be4106e115e35"
     },
     {
         "severity": "critical",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -189,6 +189,7 @@ class TestIntegration(TestCase):
         self.assertEqual(1, retval)
         self.assertEqual(
             '\n'.join([
+                "Config parsing for suite 'Suite Two' completed",
                 "Suite One &amp; Suite Two.Suite Two.Another test",
                 "Suite 'Suite Two': 1 warnings found",
                 "Counted failures for test suite 'Suite Two'.",
@@ -198,6 +199,8 @@ class TestIntegration(TestCase):
         )
 
     def test_robot_config(self):
+        os.environ['MIN_ROBOT_WARNINGS'] = '0'
+        os.environ['MAX_ROBOT_WARNINGS'] = '0'
         with patch('sys.stdout', new=StringIO()) as fake_out:
             retval = warnings_wrapper([
                 '--config',
@@ -208,6 +211,10 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
+                "Config parsing for suite 'Suite One' completed",
+                "Config parsing for suite '' completed",
+                "Config parsing for suite 'Suite Two' completed",
+                "Config parsing for suite 'b4d su1te name' completed",
                 "Config parsing for robot completed",
                 "Suite 'Suite One': 1 warnings found",
                 "2 warnings found",
@@ -225,6 +232,9 @@ class TestIntegration(TestCase):
             stdout_log
         )
         self.assertEqual(2, retval)
+        for var in ('MIN_ROBOT_WARNINGS', 'MAX_ROBOT_WARNINGS'):
+            if var in os.environ:
+                del os.environ[var]
 
     def test_robot_config_check_names(self):
         self.maxDiff = None
@@ -236,6 +246,9 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
+                "Config parsing for suite 'b4d su1te name' completed",
+                "Config parsing for suite '' completed",
+                "Config parsing for suite 'Suite Two' completed",
                 "Config parsing for robot completed",
                 "ERROR: No suite with name 'b4d su1te name' found. Returning error code -1.",
             ]) + '\n',
@@ -253,6 +266,7 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
+                "Config parsing for suite 'Inv4lid Name' completed",
                 "ERROR: No suite with name 'Inv4lid Name' found. Returning error code -1.",
             ]) + '\n',
             stdout_log
@@ -281,6 +295,8 @@ class TestIntegration(TestCase):
         self.assertTrue(filecmp.cmp(out_file, ref_file), '{} differs from {}'.format(out_file, ref_file))
 
     def test_output_file_robot_config(self):
+        os.environ['MIN_ROBOT_WARNINGS'] = '0'
+        os.environ['MAX_ROBOT_WARNINGS'] = '0'
         filename = 'robot_double_fail_config_summary.txt'
         out_file = str(TEST_OUT_DIR / filename)
         ref_file = str(TEST_IN_DIR / filename)
@@ -291,6 +307,9 @@ class TestIntegration(TestCase):
         ])
         self.assertEqual(2, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file), '{} differs from {}'.format(out_file, ref_file))
+        for var in ('MIN_ROBOT_WARNINGS', 'MAX_ROBOT_WARNINGS'):
+            if var in os.environ:
+                del os.environ[var]
 
     def test_output_file_junit(self):
         filename = 'junit_double_fail_summary.txt'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -189,7 +189,6 @@ class TestIntegration(TestCase):
         self.assertEqual(1, retval)
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'Suite Two' completed",
                 "Suite One &amp; Suite Two.Suite Two.Another test",
                 "Suite 'Suite Two': 1 warnings found",
                 "Counted failures for test suite 'Suite Two'.",
@@ -211,10 +210,6 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'Suite One' completed",
-                "Config parsing for suite '' completed",
-                "Config parsing for suite 'Suite Two' completed",
-                "Config parsing for suite 'b4d su1te name' completed",
                 "Config parsing for robot completed",
                 "Suite 'Suite One': 1 warnings found",
                 "2 warnings found",
@@ -246,9 +241,6 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'b4d su1te name' completed",
-                "Config parsing for suite '' completed",
-                "Config parsing for suite 'Suite Two' completed",
                 "Config parsing for robot completed",
                 "ERROR: No suite with name 'b4d su1te name' found. Returning error code -1.",
             ]) + '\n',
@@ -266,7 +258,6 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'Inv4lid Name' completed",
                 "ERROR: No suite with name 'Inv4lid Name' found. Returning error code -1.",
             ]) + '\n',
             stdout_log

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -189,7 +189,6 @@ class TestIntegration(TestCase):
         self.assertEqual(1, retval)
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'Suite Two' completed",
                 "Suite One &amp; Suite Two.Suite Two.Another test",
                 "Suite 'Suite Two': 1 warnings found",
                 "Counted failures for test suite 'Suite Two'.",
@@ -199,8 +198,6 @@ class TestIntegration(TestCase):
         )
 
     def test_robot_config(self):
-        os.environ['MIN_ROBOT_WARNINGS'] = '0'
-        os.environ['MAX_ROBOT_WARNINGS'] = '0'
         with patch('sys.stdout', new=StringIO()) as fake_out:
             retval = warnings_wrapper([
                 '--config',
@@ -211,10 +208,6 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'Suite One' completed",
-                "Config parsing for suite '' completed",
-                "Config parsing for suite 'Suite Two' completed",
-                "Config parsing for suite 'b4d su1te name' completed",
                 "Config parsing for robot completed",
                 "Suite 'Suite One': 1 warnings found",
                 "2 warnings found",
@@ -232,9 +225,6 @@ class TestIntegration(TestCase):
             stdout_log
         )
         self.assertEqual(2, retval)
-        for var in ('MIN_ROBOT_WARNINGS', 'MAX_ROBOT_WARNINGS'):
-            if var in os.environ:
-                del os.environ[var]
 
     def test_robot_config_check_names(self):
         self.maxDiff = None
@@ -246,9 +236,6 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'b4d su1te name' completed",
-                "Config parsing for suite '' completed",
-                "Config parsing for suite 'Suite Two' completed",
                 "Config parsing for robot completed",
                 "ERROR: No suite with name 'b4d su1te name' found. Returning error code -1.",
             ]) + '\n',
@@ -266,7 +253,6 @@ class TestIntegration(TestCase):
 
         self.assertEqual(
             '\n'.join([
-                "Config parsing for suite 'Inv4lid Name' completed",
                 "ERROR: No suite with name 'Inv4lid Name' found. Returning error code -1.",
             ]) + '\n',
             stdout_log
@@ -295,8 +281,6 @@ class TestIntegration(TestCase):
         self.assertTrue(filecmp.cmp(out_file, ref_file), '{} differs from {}'.format(out_file, ref_file))
 
     def test_output_file_robot_config(self):
-        os.environ['MIN_ROBOT_WARNINGS'] = '0'
-        os.environ['MAX_ROBOT_WARNINGS'] = '0'
         filename = 'robot_double_fail_config_summary.txt'
         out_file = str(TEST_OUT_DIR / filename)
         ref_file = str(TEST_IN_DIR / filename)
@@ -307,9 +291,6 @@ class TestIntegration(TestCase):
         ])
         self.assertEqual(2, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file), '{} differs from {}'.format(out_file, ref_file))
-        for var in ('MIN_ROBOT_WARNINGS', 'MAX_ROBOT_WARNINGS'):
-            if var in os.environ:
-                del os.environ[var]
 
     def test_output_file_junit(self):
         filename = 'junit_double_fail_summary.txt'

--- a/tests/test_polyspace.py
+++ b/tests/test_polyspace.py
@@ -66,11 +66,11 @@ class TestBugFinderWarnings(unittest.TestCase):
 
 class TestPolyspaceWarnings(unittest.TestCase):
     def setUp(self):
-        os.environ['MIN_SPHINX_WARNINGS'] = '0'
-        os.environ['MAX_SPHINX_WARNINGS'] = '0'
+        os.environ['MIN_POLY_WARNINGS'] = '0'
+        os.environ['MAX_POLY_WARNINGS'] = '0'
 
     def tearDown(self):
-        for var in ('MIN_SPHINX_WARNINGS', 'MAX_SPHINX_WARNINGS'):
+        for var in ('MIN_POLY_WARNINGS', 'MAX_POLY_WARNINGS'):
             if var in os.environ:
                 del os.environ[var]
 

--- a/tests/test_polyspace.py
+++ b/tests/test_polyspace.py
@@ -66,11 +66,11 @@ class TestBugFinderWarnings(unittest.TestCase):
 
 class TestPolyspaceWarnings(unittest.TestCase):
     def setUp(self):
-        os.environ['MIN_POLY_WARNINGS'] = '0'
-        os.environ['MAX_POLY_WARNINGS'] = '0'
+        os.environ['MIN_SPHINX_WARNINGS'] = '0'
+        os.environ['MAX_SPHINX_WARNINGS'] = '0'
 
     def tearDown(self):
-        for var in ('MIN_POLY_WARNINGS', 'MAX_POLY_WARNINGS'):
+        for var in ('MIN_SPHINX_WARNINGS', 'MAX_SPHINX_WARNINGS'):
             if var in os.environ:
                 del os.environ[var]
 

--- a/tests/test_polyspace.py
+++ b/tests/test_polyspace.py
@@ -36,7 +36,7 @@ class TestCodeProverWarnings(unittest.TestCase):
                 stdout_log
             )
         self.assertEqual(count, count_sum)
-        self.assertEqual(count, 24)
+        self.assertEqual(count, 19)
 
 
 class TestBugFinderWarnings(unittest.TestCase):
@@ -79,7 +79,7 @@ class TestPolyspaceWarnings(unittest.TestCase):
             '--config', str(TEST_IN_DIR / 'config_example_polyspace.yml'),
             str(TEST_IN_DIR / 'polyspace.tsv')
         ])
-        self.assertEqual(66, retval)
+        self.assertEqual(61, retval)
 
     def test_code_quality(self):
         filename = 'polyspace_code_quality.json'
@@ -90,7 +90,7 @@ class TestPolyspaceWarnings(unittest.TestCase):
             '--config', str(TEST_IN_DIR / 'config_example_polyspace.yml'),
             str(TEST_IN_DIR / 'polyspace.tsv'),
         ])
-        self.assertEqual(66, retval)
+        self.assertEqual(61, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file))
 
     def test_code_quality_no_green(self):
@@ -101,7 +101,7 @@ class TestPolyspaceWarnings(unittest.TestCase):
             '--config', str(TEST_IN_DIR / 'config_example_polyspace_green.yml'),
             str(TEST_IN_DIR / 'polyspace.tsv'),
         ])
-        self.assertEqual(66, retval)
+        self.assertEqual(61, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file))
 
     def test_exclude_yaml_config(self):


### PR DESCRIPTION
- Exclude Polyspace defects with a status "Not a Defect" or "Justified"
- Make it possible to use environment variables for `min` and `max` keys instead of numbers