### PR TITLE
Add code quality report to CoverityChecker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,7 +227,7 @@ a text file (`warnings_coverity.txt`) and a code quality JSON file (`coverity_co
 
 This is an example of the configuration file:
 
-.. code-block:: yml
+.. code-block:: yaml
 
     sphinx:
         enabled: false

--- a/README.rst
+++ b/README.rst
@@ -586,10 +586,8 @@ Polyspace
   The default template is ``Polyspace: $check``.
 
 Coverity
-  Named groups of the regular expression can also be used, next to environment variables.
-  The capturing groups are: `path`, `line`, `column`, `curr`, `max`, `checker` and `classification`.
-  `curr` and `max` represents respectively the current warning and the maximum amount of warnings with the same CID.
-  These are always the same if you take the note of `Parse for Coverity Defects`_ into account.
+  Named groups of the regular expression can be used as variables.
+  Useful names are: `checker` and `classification`.
   The default template is ``Coverity: $checker``.
 
 Other

--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ the ``--command`` argument and execute the ``cov-run-desktop`` through
 .. code-block:: bash
 
     # command line log file
-    mlx-warnings cov-run-desktop-output.txt --coverity
+    mlx-warnings --coverity cov-run-desktop-output.txt
     # command line command execution
     mlx-warnings --coverity --command <commandforcoverity>
 

--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,6 @@ between your branch and master, which it then forwards to ``cov-run-desktop``:
 
     cov-run-desktop --text-output-style=oneline `git diff --name-only --ignore-submodules master`
 
-
 You can pipe the results to logfile, which you pass to warnings-plugin, or you use
 the ``--command`` argument and execute the ``cov-run-desktop`` through
 
@@ -210,6 +209,50 @@ the ``--command`` argument and execute the ``cov-run-desktop`` through
     # explicitly as python module
     python3 -m mlx.warnings --coverity --command <commandforcoverity>
     python -m mlx.warnings --coverity --command <commandforcoverity>
+
+
+We utilize `cov-run-desktop` in the following manner, where the output is saved in `coverity.log`:
+
+.. code-block:: bash
+
+    cov-run-desktop --text-output-style=oneline --exit1-if-defects false --triage-attribute-regex "classification" ".*" <coverity_files> | tee coverity.log
+
+Subsequently, we process the `coverity.log` file with the mlx-warnings plugin.
+The plugin uses a configuration file (`warnings_coverity.yml`) and produces two outputs:
+a text file (`warnings_coverity.txt`) and a code quality JSON file (`coverity_code_quality.json`).
+
+.. code-block:: bash
+
+    mlx-warnings --config warnings_coverity.yml -o warnings_coverity.txt -C coverity_code_quality.json coverity.log
+
+This is an example of the configuration file:
+
+.. code-block:: yml
+
+    sphinx:
+        enabled: false
+    doxygen:
+        enabled: false
+    junit:
+        enabled: false
+    xmlrunner:
+        enabled: false
+    coverity:
+        enabled: true
+        intentional:
+            max: -1
+        bug:
+            max: 0
+        pending:
+            max: 0
+        false_positive:
+            max: -1
+    robot:
+        enabled: false
+    polyspace:
+        enabled: false
+
+For each classification, a minimum and maximum can be given.
 
 
 Parse for JUnit Failures
@@ -392,8 +435,14 @@ The values for 'min' and 'max' can be set with environment variables via a
         },
         "coverity": {
             "enabled": false,
-            "min": 0,
-            "max": 0
+            "bug": {
+                "min": 0,
+                "max": 0
+            },
+            "pending": {
+                "min": 0,
+                "max": 0
+            }
         },
         "robot": {
             "enabled": false,

--- a/README.rst
+++ b/README.rst
@@ -254,6 +254,8 @@ This is an example of the configuration file:
 
 For each classification, a minimum and maximum can be given.
 
+.. note::
+    The warnings-plugin counts only one warning if there are multiple warnings for the same CID.
 
 Parse for JUnit Failures
 ------------------------
@@ -582,6 +584,13 @@ Polyspace
   Any field of a Polyspace defect can be included by using the corresponding
   `column title <Exporting Polyspace Results_>`_ in lowercase as the variable name.
   The default template is ``Polyspace: $check``.
+
+Coverity
+  Named groups of the regular expression can also be used, next to environment variables.
+  The capturing groups are: `path`, `line`, `column`, `curr`, `max`, `checker` and `classification`.
+  `curr` and `max` represents respectively the current warning and the maximum amount of warnings with the same CID.
+  These are always the same if you take the note of `Parse for Coverity Defects`_ into account.
+  The default template is ``Coverity: $checker``.
 
 Other
   The template should contain ``$description``, which is the default.

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -245,7 +245,7 @@ class PolyspaceFamilyChecker(WarningsChecker):
         finding["description"] = description
         exclude = ("new", "status", "severity", "comment", "key")
         row_without_key = [value for key, value in row.items() if key not in exclude]
-        finding["fingerprint"] = hashlib.md5(str(row_without_key).encode('utf8')).hexdigest()
+        finding["fingerprint"] = hashlib.md5(str(row_without_key).encode('utf-8')).hexdigest()
         self.cq_findings.append(finding)
 
     def check(self, content):

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -183,7 +183,7 @@ class CoverityChecker(RegexChecker):
             self.cq_description_template = Template(value)
         if value := config.pop("cq_default_path", None):
             self.cq_default_path = value
-        if value:= config.pop("exclude", None):
+        if value := config.pop("exclude", None):
             self.add_patterns(value, self.exclude_patterns)
         for classification in config:
             if classification in ["unclassified", "pending", "false_positive", "intentional", "bug"]:

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -173,7 +173,7 @@ class CoverityChecker(RegexChecker):
                 checker.check(match)
 
     def parse_config(self, config):
-        """Parsing configuration dict extracted by previously opened JSON or yaml/yml file
+        """Process configuration
 
         Args:
             config (dict): Content of configuration file

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -268,8 +268,8 @@ class CoverityClassificationChecker(WarningsChecker):
         except KeyError as err:
             raise WarningsConfigError(f"Failed to find environment variable from configuration value "
                                       f"'cq_description_template': {err}") from err
-        if "classification" in groups:
-            finding["severity"] = self.SEVERITY_MAP[groups.get("classification", "unclassified").lower()]
+        if classification_raw := groups.get("classification"):
+            finding["severity"] = self.SEVERITY_MAP[classification_raw.lower()]
         if "path" in groups:
             path = Path(groups["path"])
             if path.is_absolute():

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -96,7 +96,7 @@ class RegexChecker(WarningsChecker):
                     lineno = 1
                 finding["location"]["lines"]["begin"] = lineno
                 break
-        finding["fingerprint"] = hashlib.md5(str(finding).encode('utf8')).hexdigest()
+        finding["fingerprint"] = hashlib.md5(str(finding).encode('utf-8')).hexdigest()
         self.cq_findings.append(finding)
 
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -103,6 +103,14 @@ class CoverityChecker(RegexChecker):
     pattern = coverity_pattern
     checkers = {}
 
+    @property
+    def counted_warnings(self):
+        ''' List: list of counted warnings (str) '''
+        all_counted_warnings = []
+        for checker in self.checkers.values():
+            all_counted_warnings.extend(checker.counted_warnings)
+        return all_counted_warnings
+
     def return_count(self):
         ''' Getter function for the amount of warnings found
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -49,6 +49,11 @@ class RegexChecker(WarningsChecker):
                 self.add_code_quality_finding(match)
 
     def add_code_quality_finding(self, match):
+        '''Add code quality finding
+
+        Args:
+            match (re.Match): The regex match
+        '''
         finding = {
             "severity": "major",
             "location": {

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -288,8 +288,8 @@ class CoverityClassificationChecker(WarningsChecker):
 
     def check(self, content):
         '''
-        Function for counting the number of warnings, but adopted for Coverity
-        output
+        Function for counting the number of warnings, but adopted for Coverity output.
+        Multiple warnings for the same CID are counted as one.
 
         Args:
             content (re.Match): The regex match

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -104,8 +104,8 @@ class CoverityChecker(RegexChecker):
     name = 'coverity'
     pattern = coverity_pattern
 
-    def __init__(self, verbose=False):
-        super().__init__(verbose)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self._cq_description_template = Template('Coverity: $checker')
         self.checkers = {}
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -186,15 +186,15 @@ class CoverityChecker(RegexChecker):
         if value := config.pop("exclude", None):
             self.add_patterns(value, self.exclude_patterns)
         for classification in config:
-            if classification in ["unclassified", "pending", "false_positive", "intentional", "bug"]:
-                classification_lower = classification.lower().replace("_", " ")
-                checker = CoverityClassificationChecker(classification=classification_lower, verbose=self.verbose)
+            classification_key = classification.lower().replace("_", " ")
+            if classification_key in CoverityClassificationChecker.SEVERITY_MAP:
+                checker = CoverityClassificationChecker(classification=classification_key, verbose=self.verbose)
                 if maximum := config[classification].get("max", 0):
                     checker.maximum = int(maximum)
                 if minimum := config[classification].get("min", 0):
                     checker.minimum = int(minimum)
                 checker.cq_findings = self.cq_findings  # share object with sub-checkers
-                self.checkers[classification_lower] = checker
+                self.checkers[classification_key] = checker
             else:
                 print(f"WARNING: Unrecognized classification {classification!r}")
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -190,9 +190,9 @@ class CoverityChecker(RegexChecker):
             if classification_key in CoverityClassificationChecker.SEVERITY_MAP:
                 checker = CoverityClassificationChecker(classification=classification_key, verbose=self.verbose)
                 if maximum := checker_config.get("max", 0):
-                    checker.maximum = int(maximum, 0)
+                    checker.maximum = int(maximum)
                 if minimum := checker_config.get("min", 0):
-                    checker.minimum = int(minimum, 0)
+                    checker.minimum = int(minimum)
                 checker.cq_findings = self.cq_findings  # share object with sub-checkers
                 self.checkers[classification_key] = checker
             else:

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -293,7 +293,7 @@ class CoverityClassificationChecker(WarningsChecker):
             finding["location"]["positions"]["begin"]["column"] = column_number
 
         finding["description"] = description
-        finding["fingerprint"] = hashlib.md5(str(match.group(0).strip()).encode('utf8')).hexdigest()
+        finding["fingerprint"] = hashlib.md5(str(match.group(0).strip()).encode('utf-8')).hexdigest()
         self.cq_findings.append(finding)
 
     def check(self, content):

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -16,7 +16,7 @@ sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 PYTHON_XMLRUNNER_REGEX = r"(\s*(?P<severity1>ERROR|FAILED) (\[\d+\.\d{3}s\]: \s*(?P<description1>.+)))\n?"
 xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 
-COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<col>\d+))?)?: ?CID \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+): (?P<classification>[\w ]+),.+"
+COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<column>\d+))?)?: ?CID \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+): (?P<classification>[\w ]+),.+"
 coverity_pattern = re.compile(COVERITY_WARNING_REGEX)
 
 
@@ -275,17 +275,12 @@ class CoverityClassificationChecker(WarningsChecker):
                     raise ValueError("Failed to convert abolute path to relative path for Code Quality report: "
                                      f"{err}") from err
             finding["location"]["path"] = str(path)
-        if "line" in groups:
-            try:
-                line_number = int(groups["line"], 0)
-            except (TypeError, ValueError):
-                line_number = 1
-            finding["location"]["positions"]["begin"]["line"] = line_number
-        if "col" in groups:
-            try:
-                finding["location"]["positions"]["begin"]["column"] = int(groups["col"], 0)
-            except (TypeError, ValueError):
-                pass
+        for group_name in ("line", "column"):
+            if group_name in groups:
+                try:
+                    finding["location"]["positions"]["begin"][group_name] = int(groups[group_name], 0)
+                except (TypeError, ValueError):
+                    pass
 
         finding["description"] = description
         finding["fingerprint"] = hashlib.md5(str(match.group(0).strip()).encode('utf-8')).hexdigest()

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -185,14 +185,14 @@ class CoverityChecker(RegexChecker):
             self.cq_default_path = value
         if value := config.pop("exclude", None):
             self.add_patterns(value, self.exclude_patterns)
-        for classification in config:
+        for classification, checker_config in config.items():
             classification_key = classification.lower().replace("_", " ")
             if classification_key in CoverityClassificationChecker.SEVERITY_MAP:
                 checker = CoverityClassificationChecker(classification=classification_key, verbose=self.verbose)
-                if maximum := config[classification].get("max", 0):
-                    checker.maximum = int(maximum)
-                if minimum := config[classification].get("min", 0):
-                    checker.minimum = int(minimum)
+                if maximum := checker_config.get("max", 0):
+                    checker.maximum = int(maximum, 0)
+                if minimum := checker_config.get("min", 0):
+                    checker.minimum = int(minimum, 0)
                 checker.cq_findings = self.cq_findings  # share object with sub-checkers
                 self.checkers[classification_key] = checker
             else:

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -189,9 +189,9 @@ class CoverityChecker(RegexChecker):
             if classification in ["unclassified", "pending", "false_positive", "intentional", "bug"]:
                 classification_lower = classification.lower().replace("_", " ")
                 checker = CoverityClassificationChecker(classification=classification_lower, verbose=self.verbose)
-                if isinstance((maximum := config[classification].get("max", 0)), (int, str)):
+                if maximum := config[classification].get("max", 0):
                     checker.maximum = int(maximum)
-                if isinstance((minimum := config[classification].get("min", 0)), (int, str)):
+                if minimum := config[classification].get("min", 0):
                     checker.minimum = int(minimum)
                 checker.cq_findings = self.cq_findings  # share object with sub-checkers
                 self.checkers[classification_lower] = checker

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -16,7 +16,7 @@ sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 PYTHON_XMLRUNNER_REGEX = r"(\s*(?P<severity1>ERROR|FAILED) (\[\d+\.\d{3}s\]: \s*(?P<description1>.+)))\n?"
 xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 
-COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<col>\d+))?)?: ?(CID) \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+\)): (?P<classification>[\w ]+), *(.+)\n?"
+COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<col>\d+))?)?: ?CID \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+): (?P<classification>[\w ]+),.+"
 coverity_pattern = re.compile(COVERITY_WARNING_REGEX)
 
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -103,11 +103,11 @@ class RegexChecker(WarningsChecker):
 class CoverityChecker(RegexChecker):
     name = 'coverity'
     pattern = coverity_pattern
-    checkers = {}
 
     def __init__(self, verbose=False):
         super().__init__(verbose)
         self._cq_description_template = Template('Coverity: $checker')
+        self.checkers = {}
 
     @property
     def counted_warnings(self):

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -287,10 +287,9 @@ class CoverityClassificationChecker(WarningsChecker):
             finding["location"]["positions"]["begin"]["line"] = line_number
         if "col" in groups:
             try:
-                column_number = int(groups["col"], 0)
+                finding["location"]["positions"]["begin"]["column"] = int(groups["col"], 0)
             except (TypeError, ValueError):
-                column_number = 1
-            finding["location"]["positions"]["begin"]["column"] = column_number
+                pass
 
         finding["description"] = description
         finding["fingerprint"] = hashlib.md5(str(match.group(0).strip()).encode('utf-8')).hexdigest()

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -305,7 +305,7 @@ class CoverityClassificationChecker(WarningsChecker):
             content (re.Match): The regex match
         '''
         match_string = content.group(0).strip()
-        if not self._is_excluded(match_string):
+        if not self._is_excluded(match_string) and (content.group('curr') == content.group('max')):
             self.count += 1
             self.counted_warnings.append(match_string)
             self.print_when_verbose(match_string)

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -104,8 +104,8 @@ class CoverityChecker(RegexChecker):
     name = 'coverity'
     pattern = coverity_pattern
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, verbose=False):
+        super().__init__(verbose)
         self._cq_description_template = Template('Coverity: $checker')
         self.checkers = {}
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -13,7 +13,7 @@ sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 PYTHON_XMLRUNNER_REGEX = r"(\s*(?P<severity1>ERROR|FAILED) (\[\d+\.\d{3}s\]: \s*(?P<description1>.+)))\n?"
 xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 
-COVERITY_WARNING_REGEX = r"(?:((?:[/.]|[A-Za-z]).+?):(-?\d+):) (CID) \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+\)): (?P<classification>\w+), *(.+)\n?"
+COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<col>\d+))?)?: ?(CID) \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+\)): (?P<classification>[\w ]+), *(.+)\n?"
 coverity_pattern = re.compile(COVERITY_WARNING_REGEX)
 
 

--- a/src/mlx/warnings/warnings.py
+++ b/src/mlx/warnings/warnings.py
@@ -59,7 +59,7 @@ class WarningsPlugin:
         Args:
             checker (WarningsChecker): checker object
         '''
-        checker.cq_enabled = self.cq_enabled and checker.name in ('doxygen', 'sphinx', 'xmlrunner', 'polyspace')
+        checker.cq_enabled = self.cq_enabled and checker.name in ('doxygen', 'sphinx', 'xmlrunner', 'polyspace', 'coverity')
         self.activated_checkers[checker.name] = checker
 
     def activate_checker_name(self, name):

--- a/src/mlx/warnings/warnings_checker.py
+++ b/src/mlx/warnings/warnings_checker.py
@@ -1,4 +1,5 @@
 import abc
+from math import inf
 import os
 import re
 from string import Template
@@ -78,6 +79,8 @@ class WarningsChecker:
 
     @maximum.setter
     def maximum(self, maximum):
+        if maximum == -1:
+            maximum = inf
         if self._minimum > maximum:
             raise ValueError("Invalid argument: maximum limit must be higher than minimum limit ({min}); cannot "
                              "set {max}.".format(max=maximum, min=self._minimum))

--- a/tests/test_in/config_example.json
+++ b/tests/test_in/config_example.json
@@ -23,8 +23,21 @@
     },
     "coverity": {
         "enabled": true,
-        "min": 0,
-        "max": 0
+        "cq_default_path": "dummy/path",
+        "intentional": {
+            "min": 0,
+            "max": "-1"
+        },
+        "bug": {
+            "max": 0
+        },
+        "pending": {
+            "min": 0,
+            "max": 0
+        },
+        "false_positive": {
+            "max": -1
+        }
     },
     "robot": {
         "enabled": false,

--- a/tests/test_in/mixed_warnings.txt
+++ b/tests/test_in/mixed_warnings.txt
@@ -15,5 +15,5 @@ WARNING: List item 'CL-UNDEFINED_CL_ITEM' in merge/pull request 138 is not defin
 'ERROR [0.000s]: test_some_error_test (something.anything.somewhere)'
 
 # Coverity
-/src/somefile.c:82: CID 113396 (#2 of 2): Coding standard violation (MISRA C-2012 Rule 10.1): Unclassified, Unspecified, Undecided, owner is nobody, first detected on 2017-07-27.
-
+/home/user/myproject/src/somefile.c:82: CID 113396 (#2 of 2): Coding standard violation (MISRA C-2012 Rule 10.1): Unclassified, Unspecified, Undecided, owner is nobody, first detected on 2017-07-27.
+src/somefile.c:82: CID 113396 (#2 of 2): Coding standard violation (MISRA C-2012 Rule 10.1): Unclassified, Unspecified, Undecided, owner is nobody, first detected on 2017-07-27.


### PR DESCRIPTION
Use a detailed configuration for counting different classifications, for example:
```
"coverity": {
        "enabled": true,
        "intentional": {
            "min": 0,
            "max": "-1"
        },
        "bug": {
            "max": 0
        },
        "pending": {
            "min": 0,
            "max": 0
        },
        "false_positive": {
            "max": -1
        }
```
`-1` represents `math.inf` what can be seen as "do not count". This can only be used for `max` and can also be used in other checkers.