### PR TITLE
Add SPDX identifier to all the source files

### DIFF
--- a/src/mlx/warnings/__main__.py
+++ b/src/mlx/warnings/__main__.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#  SPDX-License-Identifier: Apache-2.0
+
 """
 Python module for running the warnings plugin
 """

--- a/src/mlx/warnings/exceptions.py
+++ b/src/mlx/warnings/exceptions.py
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
 class WarningsConfigError(Exception):
     pass

--- a/src/mlx/warnings/junit_checker.py
+++ b/src/mlx/warnings/junit_checker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 try:
     from lxml import etree
 except ImportError:

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import csv
 import hashlib
 from io import TextIOWrapper

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -1,3 +1,5 @@
+#  SPDX-License-Identifier: Apache-2.0
+
 import hashlib
 import os
 import re

--- a/src/mlx/warnings/robot_checker.py
+++ b/src/mlx/warnings/robot_checker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 
 from junitparser import Error, Failure

--- a/src/mlx/warnings/warnings.py
+++ b/src/mlx/warnings/warnings.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import errno

--- a/src/mlx/warnings/warnings_checker.py
+++ b/src/mlx/warnings/warnings_checker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import abc
 from math import inf
 import os


### PR DESCRIPTION
One of the Best practices is to us SPDX identifiers for your source files to present  license file. I have added it to all the packaged source files, as that is what is delivered to the customer.

https://spdx.dev/learn/handling-license-info/#how

As a side action I added coding stuff to the `__main__.py` which did not have it before, but it had `python entrypoint`