### PR TITLE
Include CID of Coverity defects in CQ report

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine
+        pip install 'twine>=6.0.1'
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/README.rst
+++ b/README.rst
@@ -589,7 +589,7 @@ Polyspace
 Coverity
   Named groups of the regular expression can be used as variables.
   Useful names are: `checker` and `classification`.
-  The default template is ``Coverity: $checker``.
+  The default template is ``Coverity: CID $cid: $checker``.
 
 Other
   The template should contain ``$description``, which is the default.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 description_file = README.rst
 
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 norecursedirs= .tox
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 description_file = README.rst
 
+[bdist_wheel]
+universal=1
+
 [tool:pytest]
 norecursedirs= .tox
 

--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -15,7 +15,7 @@ sphinx_pattern = re.compile(SPHINX_WARNING_REGEX)
 PYTHON_XMLRUNNER_REGEX = r"(\s*(?P<severity1>ERROR|FAILED) (\[\d+\.\d{3}s\]: \s*(?P<description1>.+)))\n?"
 xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 
-COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<column>\d+))?)?: ?CID \d+ \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+): (?P<classification>[\w ]+),.+"
+COVERITY_WARNING_REGEX = r"(?P<path>[\d\w/\\/-_]+\.\w+)(:(?P<line>\d+)(:(?P<column>\d+))?)?: ?CID (?P<cid>\d+) \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+): (?P<classification>[\w ]+),.+"
 coverity_pattern = re.compile(COVERITY_WARNING_REGEX)
 
 
@@ -77,7 +77,7 @@ class CoverityChecker(RegexChecker):
 
     def __init__(self, verbose=False):
         super().__init__(verbose)
-        self._cq_description_template = Template('Coverity: $checker')
+        self._cq_description_template = Template('Coverity: CID $cid: $checker')
         self.checkers = {
             "unclassified": CoverityClassificationChecker("unclassified", verbose=self.verbose),
             "pending": CoverityClassificationChecker("pending", verbose=self.verbose),

--- a/tests/test_coverity.py
+++ b/tests/test_coverity.py
@@ -19,6 +19,7 @@ def ordered(obj):
     else:
         return obj
 
+
 @mock.patch.dict(os.environ, {
     "MIN_UNCLASSIFIED": "8", "MAX_UNCLASSIFIED": "8",
     "MIN_INTENTIONAL": "1", "MAX_INTENTIONAL": "1",

--- a/tests/test_coverity.py
+++ b/tests/test_coverity.py
@@ -74,9 +74,9 @@ class TestCoverityWarnings(TestCase):
         retval = warnings_wrapper([
             '--coverity',
             '--code-quality', out_file,
-            str(TEST_IN_DIR / 'defects.txt'),
+            str(TEST_IN_DIR / 'coverity_full.txt'),
         ])
-        self.assertEqual(8, retval)
+        self.assertEqual(11, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file))
 
     def test_code_quality_with_config_pass(self):

--- a/tests/test_coverity.py
+++ b/tests/test_coverity.py
@@ -19,8 +19,11 @@ def ordered(obj):
     else:
         return obj
 
-
-@mock.patch.dict(os.environ, {"MIN_COV_WARNINGS": "1", "MAX_COV_WARNINGS": "2"})
+@mock.patch.dict(os.environ, {
+    "MIN_UNCLASSIFIED": "8", "MAX_UNCLASSIFIED": "8",
+    "MIN_INTENTIONAL": "1", "MAX_INTENTIONAL": "1",
+    "MIN_FALSE_POSITIVE": "2", "MAX_FALSE_POSITIVE": "2",
+})
 class TestCoverityWarnings(TestCase):
     def setUp(self):
         Finding.fingerprints = {}
@@ -76,14 +79,30 @@ class TestCoverityWarnings(TestCase):
         self.assertEqual(8, retval)
         self.assertTrue(filecmp.cmp(out_file, ref_file))
 
-    def test_code_quality_with_config(self):
+    def test_code_quality_with_config_pass(self):
         filename = 'coverity_cq.json'
         out_file = str(TEST_OUT_DIR / filename)
         ref_file = str(TEST_IN_DIR / filename)
         retval = warnings_wrapper([
             '--code-quality', out_file,
             '--config', str(TEST_IN_DIR / 'config_example_coverity.yml'),
-            str(TEST_IN_DIR / 'defects.txt'),
+            str(TEST_IN_DIR / 'coverity_full.txt'),
         ])
-        self.assertEqual(3, retval)
+        self.assertEqual(0, retval)
+        self.assertTrue(filecmp.cmp(out_file, ref_file))
+
+    @mock.patch.dict(os.environ, {
+        "MIN_UNCLASSIFIED": "11", "MAX_UNCLASSIFIED": "-1",
+        "MIN_FALSE_POSITIVE": "0", "MAX_FALSE_POSITIVE": "1",
+    })
+    def test_code_quality_with_config_fail(self):
+        filename = 'coverity_cq.json'
+        out_file = str(TEST_OUT_DIR / filename)
+        ref_file = str(TEST_IN_DIR / filename)
+        retval = warnings_wrapper([
+            '--code-quality', out_file,
+            '--config', str(TEST_IN_DIR / 'config_example_coverity.yml'),
+            str(TEST_IN_DIR / 'coverity_full.txt'),
+        ])
+        self.assertEqual(10, retval)  # 8 + 2 not within range 6 and 7
         self.assertTrue(filecmp.cmp(out_file, ref_file))

--- a/tests/test_in/code_quality.json
+++ b/tests/test_in/code_quality.json
@@ -99,7 +99,7 @@
     },
     {
         "severity": "major",
-        "description": "Coverity: Coding standard violation (MISRA C-2012 Rule 10.1)",
+        "description": "Coverity: CID 113396: Coding standard violation (MISRA C-2012 Rule 10.1)",
         "location": {
             "path": "src/somefile.c",
             "positions": {
@@ -109,20 +109,6 @@
                 }
             }
         },
-        "fingerprint": "bec264a0725556cfe0514b3aa168715c"
-    },
-    {
-        "severity": "major",
-        "description": "Coverity: Coding standard violation (MISRA C-2012 Rule 10.1)",
-        "location": {
-            "path": "src/somefile.c",
-            "positions": {
-                "begin": {
-                    "line": 82,
-                    "column": 1
-                }
-            }
-        },
-        "fingerprint": "37dd4fe77518650ac6d416ea8e2e617f"
+        "fingerprint": "ed5c5078286a009f221b523e57546983"
     }
 ]

--- a/tests/test_in/code_quality_format.json
+++ b/tests/test_in/code_quality_format.json
@@ -110,19 +110,5 @@
             }
         },
         "fingerprint": "bec264a0725556cfe0514b3aa168715c"
-    },
-    {
-        "severity": "major",
-        "description": "Coverity: Coding standard violation (MISRA C-2012 Rule 10.1)",
-        "location": {
-            "path": "src/somefile.c",
-            "positions": {
-                "begin": {
-                    "line": 82,
-                    "column": 1
-                }
-            }
-        },
-        "fingerprint": "37dd4fe77518650ac6d416ea8e2e617f"
     }
 ]

--- a/tests/test_in/config_cq_description_format.json
+++ b/tests/test_in/config_cq_description_format.json
@@ -22,6 +22,8 @@
     },
     "coverity": {
         "enabled": true,
+        "cq_default_path": "src/main.c",
+        "cq_description_template": "Coverity: $checker",
         "min": 0,
         "max": 0
     },

--- a/tests/test_in/config_example.json
+++ b/tests/test_in/config_example.json
@@ -29,6 +29,7 @@
             "max": "-1"
         },
         "bug": {
+            "min": 0,
             "max": 0
         },
         "pending": {
@@ -36,6 +37,7 @@
             "max": 0
         },
         "false_positive": {
+            "min": 0,
             "max": -1
         }
     },

--- a/tests/test_in/config_example_coverity.yml
+++ b/tests/test_in/config_example_coverity.yml
@@ -1,11 +1,11 @@
 coverity:
   enabled: true
   unclassified:
-    min: $MIN_COV_WARNINGS
-    max: '$MAX_COV_WARNINGS'
+    min: $MIN_UNCLASSIFIED
+    max: '$MAX_UNCLASSIFIED'
   intentional:
-    min: 0
-    max: -1
+    min: $MIN_INTENTIONAL
+    max: $MAX_INTENTIONAL
   bug:
     min: 0
     max: 0
@@ -13,8 +13,8 @@ coverity:
     min: 0
     max: 0
   false_positive:
-    min: 0
-    max: -1
+    min: $MIN_FALSE_POSITIVE
+    max: $MAX_FALSE_POSITIVE
 sphinx:
   enabled: false
 doxygen:

--- a/tests/test_in/config_example_coverity.yml
+++ b/tests/test_in/config_example_coverity.yml
@@ -6,9 +6,6 @@ coverity:
   intentional:
     min: $MIN_INTENTIONAL
     max: $MAX_INTENTIONAL
-  bug:
-    min: 0
-    max: 0
   pending:
     min: 0
     max: 0

--- a/tests/test_in/coverity_cq.json
+++ b/tests/test_in/coverity_cq.json
@@ -1,6 +1,104 @@
 [
     {
         "severity": "major",
+        "description": "Coverity: CID 446411: Infinite loop (INFINITE_LOOP)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 32,
+                    "column": 5
+                }
+            }
+        },
+        "fingerprint": "61cc73ec6e5801eabd5b14dee4eddc09"
+    },
+    {
+        "severity": "major",
+        "description": "Coverity: CID 446410: MISRA C-2012 The Essential Type Model (MISRA C-2012 Rule 10.3, Required)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 55,
+                    "column": 12
+                }
+            }
+        },
+        "fingerprint": "ee2a9b741d33d5085807562a66c7ef21"
+    },
+    {
+        "severity": "major",
+        "description": "Coverity: CID 446409: MISRA C-2012 Control Flow Expressions (MISRA C-2012 Rule 14.3, Required)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 37,
+                    "column": 13
+                }
+            }
+        },
+        "fingerprint": "0a8e4e7431af33984280c95a3289f307"
+    },
+    {
+        "severity": "major",
+        "description": "Coverity: CID 446408: Logically dead code (DEADCODE)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 37,
+                    "column": 13
+                }
+            }
+        },
+        "fingerprint": "2817d729a41e3c9af04ea9711305dd6c"
+    },
+    {
+        "severity": "major",
+        "description": "Coverity: CID 446407: MISRA C-2012 The Essential Type Model (MISRA C-2012 Rule 10.4, Required)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 36,
+                    "column": 13
+                }
+            }
+        },
+        "fingerprint": "8c2bcaf164d9104351c066775b8ce7d1"
+    },
+    {
+        "severity": "major",
+        "description": "Coverity: CID 446406: MISRA C-2012 Control Flow Expressions (MISRA C-2012 Rule 14.3, Required)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 32,
+                    "column": 5
+                }
+            }
+        },
+        "fingerprint": "98fda4d0677b7c979affa2769fc21c9f"
+    },
+    {
+        "severity": "major",
+        "description": "Coverity: CID 446405: MISRA C-2012 Unused Code (MISRA C-2012 Rule 2.2, Required)",
+        "location": {
+            "path": "some/path/boot.c",
+            "positions": {
+                "begin": {
+                    "line": 37,
+                    "column": 31
+                }
+            }
+        },
+        "fingerprint": "1cbe936313d71154034d7728387409bf"
+    },
+    {
+        "severity": "major",
         "description": "Coverity: CID 431350: MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.5, Required)",
         "location": {
             "path": "some/path/dummy_uncl.h",
@@ -12,62 +110,6 @@
             }
         },
         "fingerprint": "0feb782a7b77d9d45307dc0e1d37cabc"
-    },
-    {
-        "severity": "major",
-        "description": "Coverity: CID 431349: MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.6, Required)",
-        "location": {
-            "path": "some/path/dummy_uncl.c",
-            "positions": {
-                "begin": {
-                    "line": 1404,
-                    "column": 14
-                }
-            }
-        },
-        "fingerprint": "1b9bc9863b1d43eaa17d6bd5672e3b9d"
-    },
-    {
-        "severity": "major",
-        "description": "Coverity: CID 431348: MISRA C-2012 Identifiers (MISRA C-2012 Rule 5.8, Required)",
-        "location": {
-            "path": "some/path/dummy_uncl.c",
-            "positions": {
-                "begin": {
-                    "line": 923,
-                    "column": 13
-                }
-            }
-        },
-        "fingerprint": "c83e3d6a9d30ddc3ccc8e6c3b3e0a34a"
-    },
-    {
-        "severity": "info",
-        "description": "Coverity: CID 417642: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
-        "location": {
-            "path": "some/path/dummy_int.h",
-            "positions": {
-                "begin": {
-                    "line": 150,
-                    "column": 16
-                }
-            }
-        },
-        "fingerprint": "281a13b77a22e0b91b4b1de826e83a54"
-    },
-    {
-        "severity": "info",
-        "description": "Coverity: CID 417639: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
-        "location": {
-            "path": "some/path/dummy_int.h",
-            "positions": {
-                "begin": {
-                    "line": 164,
-                    "column": 16
-                }
-            }
-        },
-        "fingerprint": "6875f7de0399adaba119ad4945514a76"
     },
     {
         "severity": "info",

--- a/tests/test_in/coverity_cq.json
+++ b/tests/test_in/coverity_cq.json
@@ -1,7 +1,7 @@
 [
     {
         "severity": "major",
-        "description": "Coverity: MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.5, Required)",
+        "description": "Coverity: CID 431350: MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.5, Required)",
         "location": {
             "path": "some/path/dummy_uncl.h",
             "positions": {
@@ -11,11 +11,11 @@
                 }
             }
         },
-        "fingerprint": "990f3714acdb07ca108f645285bacdf8"
+        "fingerprint": "0feb782a7b77d9d45307dc0e1d37cabc"
     },
     {
         "severity": "major",
-        "description": "Coverity: MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.6, Required)",
+        "description": "Coverity: CID 431349: MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.6, Required)",
         "location": {
             "path": "some/path/dummy_uncl.c",
             "positions": {
@@ -25,11 +25,11 @@
                 }
             }
         },
-        "fingerprint": "c24f5c885dd07424839f347e7fb0cfd9"
+        "fingerprint": "1b9bc9863b1d43eaa17d6bd5672e3b9d"
     },
     {
         "severity": "major",
-        "description": "Coverity: MISRA C-2012 Identifiers (MISRA C-2012 Rule 5.8, Required)",
+        "description": "Coverity: CID 431348: MISRA C-2012 Identifiers (MISRA C-2012 Rule 5.8, Required)",
         "location": {
             "path": "some/path/dummy_uncl.c",
             "positions": {
@@ -39,11 +39,11 @@
                 }
             }
         },
-        "fingerprint": "1f2f1b28535924cd9ab0dc2635aa70c7"
+        "fingerprint": "c83e3d6a9d30ddc3ccc8e6c3b3e0a34a"
     },
     {
         "severity": "info",
-        "description": "Coverity: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
+        "description": "Coverity: CID 417642: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
         "location": {
             "path": "some/path/dummy_int.h",
             "positions": {
@@ -53,11 +53,11 @@
                 }
             }
         },
-        "fingerprint": "85d0bf611abf8c051e2c55a8fce1fbfb"
+        "fingerprint": "281a13b77a22e0b91b4b1de826e83a54"
     },
     {
         "severity": "info",
-        "description": "Coverity: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
+        "description": "Coverity: CID 417639: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
         "location": {
             "path": "some/path/dummy_int.h",
             "positions": {
@@ -67,11 +67,11 @@
                 }
             }
         },
-        "fingerprint": "b84425516a0cbd5bec06779248a726a5"
+        "fingerprint": "6875f7de0399adaba119ad4945514a76"
     },
     {
         "severity": "info",
-        "description": "Coverity: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
+        "description": "Coverity: CID 264736: MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory)",
         "location": {
             "path": "some/path/dummy_int.h",
             "positions": {
@@ -81,11 +81,11 @@
                 }
             }
         },
-        "fingerprint": "9055ea84f4a2ec57238bcc9e5bf02714"
+        "fingerprint": "717cea1e452ff1905746c1e4650f7df2"
     },
     {
         "severity": "info",
-        "description": "Coverity: Out-of-bounds write (OVERRUN)",
+        "description": "Coverity: CID 423570: Out-of-bounds write (OVERRUN)",
         "location": {
             "path": "some/path/dummy_fp.c",
             "positions": {
@@ -95,11 +95,11 @@
                 }
             }
         },
-        "fingerprint": "409c39b23baaf916ac0d0c97c3917680"
+        "fingerprint": "f4526f91c0e782d1a755afc243d8deef"
     },
     {
         "severity": "info",
-        "description": "Coverity: MISRA C-2012 Pointers and Arrays (MISRA C-2012 Rule 18.1, Required)",
+        "description": "Coverity: CID 423568: MISRA C-2012 Pointers and Arrays (MISRA C-2012 Rule 18.1, Required)",
         "location": {
             "path": "some/path/dummy_fp.c",
             "positions": {
@@ -109,6 +109,6 @@
                 }
             }
         },
-        "fingerprint": "5dbd93275d026e6b77330c48eda8d964"
+        "fingerprint": "ccf2213097d60061eb0f9b61888923f9"
     }
 ]

--- a/tests/test_in/coverity_full.txt
+++ b/tests/test_in/coverity_full.txt
@@ -1,0 +1,61 @@
+Coverity Desktop Analysis version 2024.6.1 on Linux 6.1.100+ x86_64
+[STATUS] Getting snapshot for code version date 2024-11-28T16:19:58+00:00...
+[STATUS] Downloading analysis summaries index for snapshot 234246...
+[STATUS] Attempting to capture files not known to the emit...
+[NOTE] Unable to capture some input files. Ignoring because of setting.
+Selected 3 translation units for analysis:
+* some/path/boot.c
+* src/common/component/src/component.c
+* src/common/used_component/src/used_component.c
+
+[STATUS] Parsing source files...
+[STATUS] Downloading analysis summaries for snapshot 234246...
+|0----------25-----------50----------75---------100|
+****************************************************
+[STATUS] Analyzing...
+[STATUS] Retrieving defect triage data...
+
+Detected 7 defect occurrences that pass the filter criteria.
+There are 8 suppressed defects due to filters.
+
+some/path/boot.c:32:5: CID 446411 (#1 of 1): Infinite loop (INFINITE_LOOP): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:32:5: infeasible_escape: No conditions allow control to exit the loop.
+some/path/boot.c:32:5: loop_top: Top of the loop.
+some/path/boot.c:43:5: loop_bottom: Bottom of the loop.
+some/path/boot.c:34:9: assignment: Assigning: "taskTimeCounter" = "1".
+some/path/boot.c:36:13: constant_loop_condition: Condition "taskTimeCounter == 0U" is always false so that the loop cannot exit.
+
+some/path/boot.c:55:12: CID 446410 (#1 of 1): MISRA C-2012 The Essential Type Model (MISRA C-2012 Rule 10.3, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:55:12: 1. misra_c_2012_rule_10_3_violation: Implicit conversion of "retVal" from essential type "unsigned 32-bit int" to different or narrower essential type "signed 16-bit int".
+
+some/path/boot.c:37:13: CID 446409 (#1 of 1): MISRA C-2012 Control Flow Expressions (MISRA C-2012 Rule 14.3, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:34:9: assignment: Assigning: "taskTimeCounter" = "1".
+some/path/boot.c:36:13: const: At condition "taskTimeCounter == 0U", the value of "taskTimeCounter" must be equal to 1.
+some/path/boot.c:36:9: dead_error_condition: The condition "taskTimeCounter == 0U" cannot be true.
+some/path/boot.c:37:13: misra_c_2012_rule_14_3_violation: Execution cannot reach this statement: "taskTimeCounter = 2;".
+
+some/path/boot.c:37:13: CID 446408 (#1 of 1): Logically dead code (DEADCODE): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:34:9: assignment: Assigning: "taskTimeCounter" = "1".
+some/path/boot.c:36:13: const: At condition "taskTimeCounter == 0U", the value of "taskTimeCounter" must be equal to 1.
+some/path/boot.c:36:9: dead_error_condition: The condition "taskTimeCounter == 0U" cannot be true.
+some/path/boot.c:37:13: dead_error_begin: Execution cannot reach this statement: "taskTimeCounter = 2;".
+
+some/path/boot.c:36:13: CID 446407 (#1 of 1): MISRA C-2012 The Essential Type Model (MISRA C-2012 Rule 10.4, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:36:13: 1. misra_c_2012_rule_10_4_violation: Essential type of the left hand operand "taskTimeCounter" (unsigned) is not the same as that of the right operand "0"(signed).
+
+some/path/boot.c:32:5: CID 446406 (#1 of 1): MISRA C-2012 Control Flow Expressions (MISRA C-2012 Rule 14.3, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:32:5: misra_c_2012_rule_14_3_violation: No conditions allow control to exit the loop.
+some/path/boot.c:32:5: loop_top: Top of the loop.
+some/path/boot.c:43:5: loop_bottom: Bottom of the loop.
+some/path/boot.c:34:9: assignment: Assigning: "taskTimeCounter" = "1".
+some/path/boot.c:36:13: constant_loop_condition: Condition "taskTimeCounter == 0U" is always false so that the loop cannot exit.
+
+some/path/boot.c:37:31: CID 446405 (#1 of 1): MISRA C-2012 Unused Code (MISRA C-2012 Rule 2.2, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+some/path/boot.c:37:31: misra_c_2012_rule_2_2_violation: Assigning value "2" to "taskTimeCounter" here, but that stored value is not used.
+
+some/path/dummy_int.h:34:12: CID 264736 (#1 of 1): MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory): Intentional, Minor, Ignore, owner is Unassigned, defect only exists locally.
+some/path/dummy_fp.c:367:13: CID 423570 (#1 of 1): Out-of-bounds write (OVERRUN): False Positive, Minor, Ignore, owner is sfo, defect only exists locally.
+some/path/dummy_fp.c:367:13: CID 423568 (#1 of 1): MISRA C-2012 Pointers and Arrays (MISRA C-2012 Rule 18.1, Required): False Positive, Minor, Ignore, owner is sfo, defect only exists locally.
+some/path/dummy_uncl.h:194:14: CID 431350 (#1 of 1): MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.5, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
+
+cov-run-desktop took 7.8 seconds.

--- a/tests/test_in/defects.txt
+++ b/tests/test_in/defects.txt
@@ -1,8 +1,0 @@
-some/path/dummy_int.h:150:16: CID 417642 (#1 of 1): MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory): Intentional, Minor, Ignore, owner is Unassigned, defect only exists locally.
-some/path/dummy_int.h:164:16: CID 417639 (#1 of 1): MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory): Intentional, Minor, Ignore, owner is Unassigned, defect only exists locally.
-some/path/dummy_int.h:34:12: CID 264736 (#1 of 1): MISRA C-2012 Standard C Environment (MISRA C-2012 Rule 1.2, Advisory): Intentional, Minor, Ignore, owner is Unassigned, defect only exists locally.
-some/path/dummy_fp.c:367:13: CID 423570 (#1 of 1): Out-of-bounds write (OVERRUN): False Positive, Minor, Ignore, owner is sfo, defect only exists locally.
-some/path/dummy_fp.c:367:13: CID 423568 (#1 of 1): MISRA C-2012 Pointers and Arrays (MISRA C-2012 Rule 18.1, Required): False Positive, Minor, Ignore, owner is sfo, defect only exists locally.
-some/path/dummy_uncl.h:194:14: CID 431350 (#1 of 1): MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.5, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
-some/path/dummy_uncl.c:1404:14: CID 431349 (#1 of 1): MISRA C-2012 Declarations and Definitions (MISRA C-2012 Rule 8.6, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.
-some/path/dummy_uncl.c:923:13: CID 431348 (#1 of 1): MISRA C-2012 Identifiers (MISRA C-2012 Rule 5.8, Required): Unclassified, Unspecified, Undecided, owner is Unassigned, defect only exists locally.

--- a/tests/test_in/mixed_warnings.txt
+++ b/tests/test_in/mixed_warnings.txt
@@ -15,5 +15,5 @@ WARNING: List item 'CL-UNDEFINED_CL_ITEM' in merge/pull request 138 is not defin
 'ERROR [0.000s]: test_some_error_test (something.anything.somewhere)'
 
 # Coverity
-/home/user/myproject/src/somefile.c:82: CID 113396 (#2 of 2): Coding standard violation (MISRA C-2012 Rule 10.1): Unclassified, Unspecified, Undecided, owner is nobody, first detected on 2017-07-27.
+/home/user/myproject/src/somefile.c:82: CID 113396 (#1 of 2): Coding standard violation (MISRA C-2012 Rule 10.1): Unclassified, Unspecified, Undecided, owner is nobody, first detected on 2017-07-27.
 src/somefile.c:82: CID 113396 (#2 of 2): Coding standard violation (MISRA C-2012 Rule 10.1): Unclassified, Unspecified, Undecided, owner is nobody, first detected on 2017-07-27.

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ commands =
 [testenv:check]
 deps =
     docutils
-    build
     twine >= 1.12.0
     readme-renderer
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 [testenv:check]
 deps =
     docutils
-    twine >= 1.12.0
+    twine >= 6.0.1
     readme-renderer
     flake8
     pygments


### PR DESCRIPTION
It was impossible to configure the tool to include the CID of Coverity defects in the Code Quality report. This is very useful information, however, so I decided to include it by default.

Treating this as a bug fix for release [5.5.0](https://github.com/melexis/warnings-plugin/releases/tag/5.5.0)