### PR TITLE
More robust Code Quality reports for PolyspaceChecker

### DIFF
--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -76,9 +76,10 @@ class Finding:
             line_number = int(value)
         except (TypeError, ValueError):
             line_number = 1
-
-        if line_number < 0:
-            raise ValueError(f"Expected line number greater or equal than 0; Got {line_number}")
+        if line_number == 0:
+            line_number += 1
+        elif line_number < 0:
+            raise ValueError(f"Expected line number greater than 0; Got {line_number}")
         self._line = line_number
 
     @property
@@ -93,8 +94,10 @@ class Finding:
         except (TypeError, ValueError):
             column_number = 1
 
-        if column_number < 0:
-            raise ValueError(f"Expected column number greater or equal than 0; Got {column_number}")
+        if column_number == 0:
+            column_number += 1
+        elif column_number < 0:
+            raise ValueError(f"Expected column number greater than 0; Got {column_number}")
         self._column = column_number
 
     def to_dict(self):

--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -77,8 +77,8 @@ class Finding:
         except (TypeError, ValueError):
             line_number = 1
 
-        if line_number <= 0:
-            raise ValueError(f"Expected line number greater than 0; Got {line_number}")
+        if line_number < 0:
+            raise ValueError(f"Expected line number greater or equal than 0; Got {line_number}")
         self._line = line_number
 
     @property
@@ -88,9 +88,8 @@ class Finding:
 
     @column.setter
     def column(self, value):
-        column_number = int(value)
-        if column_number <= 0:
-            raise ValueError(f"Expected column number greater than 0; Got {column_number}")
+        if column_number < 0:
+            raise ValueError(f"Expected column number greater or equal than 0; Got {column_number}")
         self._column = column_number
 
     def to_dict(self):

--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -88,6 +88,11 @@ class Finding:
 
     @column.setter
     def column(self, value):
+        try:
+            column_number = int(value)
+        except (TypeError, ValueError):
+            column_number = 1
+
         if column_number < 0:
             raise ValueError(f"Expected column number greater or equal than 0; Got {column_number}")
         self._column = column_number

--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -77,7 +77,7 @@ class Finding:
         except (TypeError, ValueError):
             line_number = 1
         if line_number == 0:
-            line_number += 1
+            line_number = 1
         elif line_number < 0:
             raise ValueError(f"Expected line number greater than 0; Got {line_number}")
         self._line = line_number
@@ -95,7 +95,7 @@ class Finding:
             column_number = 1
 
         if column_number == 0:
-            column_number += 1
+            column_number = 1
         elif column_number < 0:
             raise ValueError(f"Expected column number greater than 0; Got {column_number}")
         self._column = column_number

--- a/src/mlx/warnings/polyspace_checker.py
+++ b/src/mlx/warnings/polyspace_checker.py
@@ -230,7 +230,8 @@ class PolyspaceFamilyChecker(WarningsChecker):
                 self.logger.info(f"Excluded defect with ID {content.get('id', None)!r} because the status is "
                                  "'Not a defect' or 'Justified'")
             else:
-                tab_sep_string = "\t".join(content.values())
+                valid_content_values = [item or "" for item in content.values()]
+                tab_sep_string = "\t".join(valid_content_values)
                 if not self._is_excluded(tab_sep_string):
                     self.count = self.count + 1
                     verbose_log_msg = f"ID {content.get('id', None)!r}"

--- a/tests/test_in/polyspace.tsv
+++ b/tests/test_in/polyspace.tsv
@@ -89,11 +89,11 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 17506	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		668D2241A805FA2528D0A23360	16	-
 17507	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		4E19328805A214EB94A0438AC8A1	17	9
 17508	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		0E9B328805A214EB94A0438AC8A1	17	10
-17509	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		E6CD2241A805FA2528D0A2316A	16	11
+17509	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		E6CD2241A805FA2528D0A2316A	0	11
 17510	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		27CD2241A805FA2528D0A2316C	16	12
 17511	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		A60C2241A805FA2528D0A2316A	17	13
 17512	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		86CC2241A805FA2528D0A2316C	17	14
-17513	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		534611A054827D921468511C	18	5
+17513	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		534611A054827D921468511C	18	0
 17514	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		070C2241A805FA2528D0A2326A	18	6
 17515	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		CD1A378805A214EB94A0438AC8A9	17	6
 17516	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		864E2241A805FA2528D0A23268	17	7

--- a/tests/test_in/polyspace.tsv
+++ b/tests/test_in/polyspace.tsv
@@ -41,7 +41,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 19351	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Justified	Unset		66C8A9F4CA91263862	8	9
 19355	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8A9F4CA91263962	9	10
 19354	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9153E995234C62C091	9	11
-19358	Run-time Check	Numerical	Orange	no	Overflow	Origin: Path related issue	dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9153E995234C62C0C1	8	3
+19358	Run-time Check	Numerical	Orange	no	Overflow	Origin: Path related issue	dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9153E995234C62C0C1
 19360	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8B1F4CA91263262	8	4
 19349	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8C1F4CA91263262	9	5
 19345	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C8C1F4CA91263470	9	6
@@ -84,9 +84,9 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 22051	Run-time Check	Data flow	Gray	no	Unreachable code		dummy_function()	dummy_file_name.c	Unreviewed	Unset		3166CCB155C9941C	16	12
 22052	Run-time Check	Data flow	Gray	no	Unreachable code		dummy_function()	dummy_file_name.c	Unreviewed	Unset		3166CCB955C9941C	16	13
 17503	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		CD99338805A214EB94A0438AC8A9	15	5
-17504	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		CD99378805A214EB94A0438AC8A9	15	6
+17504	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		CD99378805A214EB94A0438AC8A9	15
 17505	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		4C18398805A214EB94A0438AC4A9	16	7
-17506	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		668D2241A805FA2528D0A23360	16	8
+17506	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		668D2241A805FA2528D0A23360	16	-
 17507	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		4E19328805A214EB94A0438AC8A1	17	9
 17508	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		0E9B328805A214EB94A0438AC8A1	17	10
 17509	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		E6CD2241A805FA2528D0A2316A	16	11

--- a/tests/test_in/polyspace_code_quality.json
+++ b/tests/test_in/polyspace_code_quality.json
@@ -160,8 +160,8 @@
             "path": "dummy_file_name.c",
             "positions": {
                 "begin": {
-                    "line": 8,
-                    "column": 3
+                    "line": 1,
+                    "column": 1
                 }
             }
         },
@@ -287,7 +287,7 @@
             "positions": {
                 "begin": {
                     "line": 15,
-                    "column": 6
+                    "column": 1
                 }
             }
         },
@@ -315,7 +315,7 @@
             "positions": {
                 "begin": {
                     "line": 16,
-                    "column": 8
+                    "column": 1
                 }
             }
         },

--- a/tests/test_in/polyspace_code_quality.json
+++ b/tests/test_in/polyspace_code_quality.json
@@ -356,7 +356,7 @@
             "path": "dummy_file_name.c",
             "positions": {
                 "begin": {
-                    "line": 16,
+                    "line": 1,
                     "column": 11
                 }
             }
@@ -413,7 +413,7 @@
             "positions": {
                 "begin": {
                     "line": 18,
-                    "column": 5
+                    "column": 1
                 }
             }
         },

--- a/tests/test_in/polyspace_code_quality_exclude.json
+++ b/tests/test_in/polyspace_code_quality_exclude.json
@@ -118,7 +118,7 @@
             "path": "dummy_file_name.c",
             "positions": {
                 "begin": {
-                    "line": 16,
+                    "line": 1,
                     "column": 11
                 }
             }
@@ -175,7 +175,7 @@
             "positions": {
                 "begin": {
                     "line": 18,
-                    "column": 5
+                    "column": 1
                 }
             }
         },

--- a/tests/test_in/polyspace_code_quality_exclude.json
+++ b/tests/test_in/polyspace_code_quality_exclude.json
@@ -49,7 +49,7 @@
             "positions": {
                 "begin": {
                     "line": 15,
-                    "column": 6
+                    "column": 1
                 }
             }
         },
@@ -77,7 +77,7 @@
             "positions": {
                 "begin": {
                     "line": 16,
-                    "column": 8
+                    "column": 1
                 }
             }
         },


### PR DESCRIPTION
- Accept the line and column values of the Polyspace's input to be 0. When the line or column is 0, the line or column in the finding will be 1. Fixes this kind of errors: `ValueError: Expected column number greater than 0; Got 0`
- line or column values defaults to 1, also when the value can't be converted to an integer

