### PR TITLE
FIX: ValueError when treating location info  '/?extern' as an absolute path

### DIFF
--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -56,14 +56,18 @@ class Finding:
 
     @path.setter
     def path(self, value):
-        path = Path(value)
-        if path.is_absolute():
-            try:
-                path = path.relative_to(Path.cwd())
-            except ValueError as err:
-                raise ValueError("Failed to convert abolute path to relative path for Code Quality report: "
-                                 f"{err}") from err
-        self._path = str(path)
+        if not value.startswith("/?"):
+            path = Path(value)
+            if path.is_absolute():
+
+                try:
+                    path = path.relative_to(Path.cwd())
+                except ValueError as err:
+                    raise ValueError("Failed to convert abolute path to relative path for Code Quality report: "
+                                    f"{err}") from err
+            self._path = str(path)
+        else:
+            self._path = value[2:]
 
     @property
     def line(self):

--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -64,7 +64,7 @@ class Finding:
                     path = path.relative_to(Path.cwd())
                 except ValueError as err:
                     raise ValueError("Failed to convert abolute path to relative path for Code Quality report: "
-                                    f"{err}") from err
+                                     f"{err}") from err
             self._path = str(path)
         else:
             self._path = value[2:]

--- a/src/mlx/warnings/code_quality.py
+++ b/src/mlx/warnings/code_quality.py
@@ -67,7 +67,7 @@ class Finding:
                                      f"{err}") from err
             self._path = str(path)
         else:
-            self._path = value[2:]
+            self._path = value[len("/?"):]
 
     @property
     def line(self):

--- a/src/mlx/warnings/warnings.py
+++ b/src/mlx/warnings/warnings.py
@@ -20,7 +20,7 @@ from .polyspace_checker import PolyspaceChecker
 from .regex_checker import CoverityChecker, DoxyChecker, SphinxChecker, XMLRunnerChecker
 from .robot_checker import RobotChecker
 
-__version__ = version("mlx.warnings")
+__version__ = version("mlx-warnings")
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/mlx/warnings/warnings.py
+++ b/src/mlx/warnings/warnings.py
@@ -9,7 +9,7 @@ import logging
 import os
 import subprocess
 import sys
-from importlib.metadata import distribution
+from importlib.metadata import version
 from pathlib import Path
 
 from ruamel.yaml import YAML
@@ -20,7 +20,7 @@ from .polyspace_checker import PolyspaceChecker
 from .regex_checker import CoverityChecker, DoxyChecker, SphinxChecker, XMLRunnerChecker
 from .robot_checker import RobotChecker
 
-__version__ = distribution("mlx.warnings").version
+__version__ = version("mlx.warnings")
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_in/polyspace.tsv
+++ b/tests/test_in/polyspace.tsv
@@ -10,7 +10,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 21999	Run-time Check	Data flow	Green	no	Non-initialized pointer		dummy_function()	dummy_file_name.c	Unreviewed	Unset		3166DC72940A8C19	3	9
 22187	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		62D889E42995263162	3	10
 22185	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		316AD87294CA131C	4	1
-22184	Run-time Check	Data flow	Green	no	Return value not initialized		dummy_function()	dummy_file_name.c	Unreviewed	Unset		316AD04A25CA8C1C	4	2
+22184	Run-time Check	Data flow	Green	no	Return value not initialized		dummy_function()	/?someothererror	Unreviewed	Unset		316AD04A25CA8C1C	4	2
 22011	Run-time Check	Numerical	Green	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		3660C87A65C8131C	3	2
 22014	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		6CC0B9E42995263162	3	3
 22010	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		3660C87294CA131C	4	4
@@ -27,7 +27,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 22035	Run-time Check	Data flow	Green	no	Non-initialized local variable		dummy_function()	dummy_file_name.c	Unreviewed	Unset		C499232693A45698C491	5	6
 21989	Run-time Check	Numerical	Green	no	Overflow		dummy_function()	dummy_file_name.c	Not a defect	Unset		C4997327D32B4698C881	6	7
 19928	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		62C8B1F4CA9126336A	6	8
-19962	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Not a defect	Unset		62D8A9F4CA91263472	7	9
+19962	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	/?extern	Not a defect	Unset		62D8A9F4CA91263472	7	9
 19526	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66C899F4CA9126316A	7	10
 19424	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Unreviewed	Unset		62E489F4CA91263262	6	11
 19429	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.h	Justified	Unset		62E4A1F4CA91263162	6	2
@@ -49,7 +49,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 19339	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Not a defect	Unset		66CC91F4CA91263464	10	8
 19338	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66CC91F4CA91263468	9	9
 19336	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		66CC91F4CA91263970	9	10
-19335	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	dummy_file_name.c	Unreviewed	Unset		CC9923E995234C62C0C9	10	11
+19335	Run-time Check	Numerical	Orange	no	Overflow		dummy_function()	/?extern	Unreviewed	Unset		CC9923E995234C62C0C9	10	11
 28766	Run-time Check	Data flow	Gray	no	Unreachable code		dummy_function()	dummy_file_name.c	Unreviewed	Unset		19396855722507	10	12
 28750	Run-time Check	Data flow	Gray	no	Unreachable code		dummy_function()	dummy_file_name.c	Unreviewed	Unset		62C8C193AA93293362	11	3
 28728	Run-time Check	Data flow	Gray	no	Unreachable code		dummy_function()	dummy_file_name.c	Unreviewed	Unset		62C88983AA9329356C	11	4
@@ -85,7 +85,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 22052	Run-time Check	Data flow	Gray	no	Unreachable code		dummy_function()	dummy_file_name.c	Unreviewed	Unset		3166CCB955C9941C	16	13
 17503	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		CD99338805A214EB94A0438AC8A9	15	5
 17504	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		CD99378805A214EB94A0438AC8A9	15
-17505	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		4C18398805A214EB94A0438AC4A9	16	7
+17505	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	/?someothererror	Unreviewed	Unset		4C18398805A214EB94A0438AC4A9	16	7
 17506	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.c	Unreviewed	Unset		668D2241A805FA2528D0A23360	16	-
 17507	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		4E19328805A214EB94A0438AC8A1	17	9
 17508	Defect	Concurrency	Red	no	Data race	Impact: High	File Scope	dummy_file_name.h	Unreviewed	Unset		0E9B328805A214EB94A0438AC8A1	17	10
@@ -129,7 +129,7 @@ ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Commen
 17560	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		3364E09A94E893AF4390057274A80D1C	22	8
 17561	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		3364D49A94E893AF4390057274A8CD18	23	9
 17562	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		3364D49A94E893AF4390057274A84E98	23	10
-17563	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		3364D89A94E893AF4390057274A88C98	24	11
+17563	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	/?extern	Unreviewed	Unset		3364D89A94E893AF4390057274A88C98	24	11
 17568	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		3970D09A94E893AF4390057274A84C9B	24	12
 17569	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		62C099936A52A34EBE0D4214C9D1A2366E	23	13
 17570	Defect	Numerical	Red	no	Sign change integer conversion overflow	Impact: Medium	dummy_function()	dummy_file_name.c	Unreviewed	Unset		62C0A1436A52A34EBE0D4214C9D1A2366E	23	14

--- a/tests/test_in/polyspace_code_quality.json
+++ b/tests/test_in/polyspace_code_quality.json
@@ -255,7 +255,7 @@
         "severity": "major",
         "description": "Polyspace: Overflow",
         "location": {
-            "path": "dummy_file_name.c",
+            "path": "extern",
             "positions": {
                 "begin": {
                     "line": 10,
@@ -263,7 +263,7 @@
                 }
             }
         },
-        "fingerprint": "9a3697faef437ec3bcdaf1c34912aad5"
+        "fingerprint": "2fd525625a9a959d2ac926a202065df7"
     },
     {
         "severity": "critical",
@@ -297,7 +297,7 @@
         "severity": "critical",
         "description": "Polyspace: Data race",
         "location": {
-            "path": "dummy_file_name.c",
+            "path": "someothererror",
             "positions": {
                 "begin": {
                     "line": 16,
@@ -305,7 +305,7 @@
                 }
             }
         },
-        "fingerprint": "cffef099a70ee703d85318b58aaee3ae"
+        "fingerprint": "fdf680bf11ff34f10ced614d3e919f80"
     },
     {
         "severity": "critical",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "fingerprint": "21c436bad7047cfb5605797b4dd2e57f"
+        "fingerprint": "cffef099a70ee703d85318b58aaee3ae"
     },
     {
         "severity": "critical",
@@ -361,7 +361,7 @@
                 }
             }
         },
-        "fingerprint": "12b0f09fa6a3a951688a1da7df58f5f6"
+        "fingerprint": "21c436bad7047cfb5605797b4dd2e57f"
     },
     {
         "severity": "critical",
@@ -375,7 +375,7 @@
                 }
             }
         },
-        "fingerprint": "44840dd6509374e45d3e4e9f6d1a791b"
+        "fingerprint": "12b0f09fa6a3a951688a1da7df58f5f6"
     },
     {
         "severity": "critical",
@@ -389,7 +389,7 @@
                 }
             }
         },
-        "fingerprint": "9b97b406a7decd5738144269e0708692"
+        "fingerprint": "44840dd6509374e45d3e4e9f6d1a791b"
     },
     {
         "severity": "critical",
@@ -403,7 +403,7 @@
                 }
             }
         },
-        "fingerprint": "638b9256aca9f3517e67e90c11063616"
+        "fingerprint": "9b97b406a7decd5738144269e0708692"
     },
     {
         "severity": "critical",
@@ -417,7 +417,7 @@
                 }
             }
         },
-        "fingerprint": "98068371b4c1f2efc59bd12de75a83d9"
+        "fingerprint": "638b9256aca9f3517e67e90c11063616"
     },
     {
         "severity": "critical",
@@ -431,7 +431,7 @@
                 }
             }
         },
-        "fingerprint": "229bd0263d410b0af1cf419502e6a507"
+        "fingerprint": "98068371b4c1f2efc59bd12de75a83d9"
     },
     {
         "severity": "critical",
@@ -459,7 +459,7 @@
                 }
             }
         },
-        "fingerprint": "ca86994653cbd6e2bd0a21a315684e25"
+        "fingerprint": "229bd0263d410b0af1cf419502e6a507"
     },
     {
         "severity": "critical",
@@ -501,7 +501,7 @@
                 }
             }
         },
-        "fingerprint": "506fa8b19ce9918b2dcee7bfcda2ac82"
+        "fingerprint": "ca86994653cbd6e2bd0a21a315684e25"
     },
     {
         "severity": "critical",
@@ -515,7 +515,7 @@
                 }
             }
         },
-        "fingerprint": "7fa6a9325e456eb1058718476beae0b2"
+        "fingerprint": "506fa8b19ce9918b2dcee7bfcda2ac82"
     },
     {
         "severity": "critical",
@@ -529,7 +529,7 @@
                 }
             }
         },
-        "fingerprint": "59cfffe68c18dbcd136a6a16ee2bbbb5"
+        "fingerprint": "7fa6a9325e456eb1058718476beae0b2"
     },
     {
         "severity": "critical",
@@ -543,7 +543,7 @@
                 }
             }
         },
-        "fingerprint": "d0bfe2255eff847bae72a167313fd2a5"
+        "fingerprint": "59cfffe68c18dbcd136a6a16ee2bbbb5"
     },
     {
         "severity": "critical",
@@ -557,7 +557,7 @@
                 }
             }
         },
-        "fingerprint": "8585e6d19f4be1e8d61c97492306077a"
+        "fingerprint": "d0bfe2255eff847bae72a167313fd2a5"
     },
     {
         "severity": "critical",
@@ -571,7 +571,7 @@
                 }
             }
         },
-        "fingerprint": "28be3be6683be483250b4d59ef3cc16d"
+        "fingerprint": "8585e6d19f4be1e8d61c97492306077a"
     },
     {
         "severity": "critical",
@@ -585,7 +585,7 @@
                 }
             }
         },
-        "fingerprint": "8be85b513aba167a92c30b337451742c"
+        "fingerprint": "28be3be6683be483250b4d59ef3cc16d"
     },
     {
         "severity": "critical",
@@ -599,7 +599,7 @@
                 }
             }
         },
-        "fingerprint": "591dad475acb333461a76cc67ae00f51"
+        "fingerprint": "8be85b513aba167a92c30b337451742c"
     },
     {
         "severity": "critical",
@@ -613,7 +613,7 @@
                 }
             }
         },
-        "fingerprint": "bb70a1151afad3baa3f91b11f97d8fa3"
+        "fingerprint": "591dad475acb333461a76cc67ae00f51"
     },
     {
         "severity": "critical",
@@ -627,7 +627,7 @@
                 }
             }
         },
-        "fingerprint": "e6a1a28fcb8acb2f3365f60adac9e3e7"
+        "fingerprint": "bb70a1151afad3baa3f91b11f97d8fa3"
     },
     {
         "severity": "critical",
@@ -669,7 +669,7 @@
                 }
             }
         },
-        "fingerprint": "ecfecca0bea5d7910d370cb8f0189b42"
+        "fingerprint": "e6a1a28fcb8acb2f3365f60adac9e3e7"
     },
     {
         "severity": "critical",
@@ -683,7 +683,7 @@
                 }
             }
         },
-        "fingerprint": "361b72a0f44c09132dfe74b4e1686562"
+        "fingerprint": "ecfecca0bea5d7910d370cb8f0189b42"
     },
     {
         "severity": "critical",
@@ -697,7 +697,7 @@
                 }
             }
         },
-        "fingerprint": "33b0de8008338b1425ffc60287deffcb"
+        "fingerprint": "361b72a0f44c09132dfe74b4e1686562"
     },
     {
         "severity": "critical",
@@ -711,7 +711,7 @@
                 }
             }
         },
-        "fingerprint": "93e43e05f593bea4d4d51a2c40366de4"
+        "fingerprint": "33b0de8008338b1425ffc60287deffcb"
     },
     {
         "severity": "critical",
@@ -753,7 +753,7 @@
                 }
             }
         },
-        "fingerprint": "bd6fd417f4b5fbe497e103eb5e0640ce"
+        "fingerprint": "93e43e05f593bea4d4d51a2c40366de4"
     },
     {
         "severity": "critical",
@@ -781,7 +781,7 @@
                 }
             }
         },
-        "fingerprint": "344fc7a680122a63080f122b9365910c"
+        "fingerprint": "bd6fd417f4b5fbe497e103eb5e0640ce"
     },
     {
         "severity": "critical",
@@ -795,7 +795,7 @@
                 }
             }
         },
-        "fingerprint": "19b12728d5681c134c1e89fd5ccf6d0e"
+        "fingerprint": "344fc7a680122a63080f122b9365910c"
     },
     {
         "severity": "critical",
@@ -809,7 +809,7 @@
                 }
             }
         },
-        "fingerprint": "fdf4cbad36c706a8007795370a78ee6e"
+        "fingerprint": "19b12728d5681c134c1e89fd5ccf6d0e"
     },
     {
         "severity": "critical",
@@ -837,7 +837,7 @@
                 }
             }
         },
-        "fingerprint": "d12420f28bc3b5dff820fc7d28753136"
+        "fingerprint": "fdf4cbad36c706a8007795370a78ee6e"
     },
     {
         "severity": "critical",
@@ -851,7 +851,7 @@
                 }
             }
         },
-        "fingerprint": "48a92e97833e72b5eec5be985a4b6423"
+        "fingerprint": "d12420f28bc3b5dff820fc7d28753136"
     },
     {
         "severity": "major",
@@ -913,7 +913,7 @@
         "severity": "major",
         "description": "Polyspace: Sign change integer conversion overflow",
         "location": {
-            "path": "dummy_file_name.c",
+            "path": "extern",
             "positions": {
                 "begin": {
                     "line": 24,
@@ -921,7 +921,7 @@
                 }
             }
         },
-        "fingerprint": "f766c4f9940d1efef8a238e5c79906dd"
+        "fingerprint": "a08609ab3a55668ec6dfcd962c7bf4c3"
     },
     {
         "severity": "major",
@@ -935,7 +935,7 @@
                 }
             }
         },
-        "fingerprint": "ecfeb007c472ddfd15ed7f3f0148b92c"
+        "fingerprint": "f766c4f9940d1efef8a238e5c79906dd"
     },
     {
         "severity": "major",
@@ -949,7 +949,7 @@
                 }
             }
         },
-        "fingerprint": "0dba0185c7ee7d9e179045298b39cca2"
+        "fingerprint": "ecfeb007c472ddfd15ed7f3f0148b92c"
     },
     {
         "severity": "major",
@@ -963,7 +963,7 @@
                 }
             }
         },
-        "fingerprint": "ea51d0f24965712bef29f7e8ebead82d"
+        "fingerprint": "0dba0185c7ee7d9e179045298b39cca2"
     },
     {
         "severity": "major",
@@ -977,7 +977,7 @@
                 }
             }
         },
-        "fingerprint": "55113c9f4327039bd2d36d66b2526021"
+        "fingerprint": "ea51d0f24965712bef29f7e8ebead82d"
     },
     {
         "severity": "minor",

--- a/tests/test_in/polyspace_code_quality_exclude.json
+++ b/tests/test_in/polyspace_code_quality_exclude.json
@@ -28,6 +28,20 @@
         "fingerprint": "bfa559b2a0fa5ade43ff6a5c39111ac7"
     },
     {
+        "severity": "major",
+        "description": "12345 Run-time Check: Overflow",
+        "location": {
+            "path": "extern",
+            "positions": {
+                "begin": {
+                    "line": 10,
+                    "column": 11
+                }
+            }
+        },
+        "fingerprint": "402c97a0997c627cdaf21d3b125b78c4"
+    },
+    {
         "severity": "critical",
         "description": "12345 Defect: Data race",
         "location": {
@@ -59,7 +73,7 @@
         "severity": "critical",
         "description": "12345 Defect: Data race",
         "location": {
-            "path": "dummy_file_name.c",
+            "path": "someothererror",
             "positions": {
                 "begin": {
                     "line": 16,
@@ -67,7 +81,7 @@
                 }
             }
         },
-        "fingerprint": "9038ff941a14172648bbb5f77ac0332b"
+        "fingerprint": "503c1ce2229191382627af02e6b5182f"
     },
     {
         "severity": "critical",
@@ -81,7 +95,7 @@
                 }
             }
         },
-        "fingerprint": "8f88c1753308517b6443b04ae44dc099"
+        "fingerprint": "9038ff941a14172648bbb5f77ac0332b"
     },
     {
         "severity": "critical",
@@ -123,7 +137,7 @@
                 }
             }
         },
-        "fingerprint": "cb493ae3841474886840e4b4ac067171"
+        "fingerprint": "8f88c1753308517b6443b04ae44dc099"
     },
     {
         "severity": "critical",
@@ -137,7 +151,7 @@
                 }
             }
         },
-        "fingerprint": "a48fb029eb7f486aa6f2235f598698fd"
+        "fingerprint": "cb493ae3841474886840e4b4ac067171"
     },
     {
         "severity": "critical",
@@ -151,7 +165,7 @@
                 }
             }
         },
-        "fingerprint": "9854126dfbf667b3cfefccf72a4c2518"
+        "fingerprint": "a48fb029eb7f486aa6f2235f598698fd"
     },
     {
         "severity": "critical",
@@ -165,7 +179,7 @@
                 }
             }
         },
-        "fingerprint": "f026f6af789a0e30dd6dd98195e9869a"
+        "fingerprint": "9854126dfbf667b3cfefccf72a4c2518"
     },
     {
         "severity": "critical",
@@ -179,7 +193,7 @@
                 }
             }
         },
-        "fingerprint": "334bbee14583a3c70de5803e481f63d9"
+        "fingerprint": "f026f6af789a0e30dd6dd98195e9869a"
     },
     {
         "severity": "critical",
@@ -193,7 +207,7 @@
                 }
             }
         },
-        "fingerprint": "4707452de6d95f470d3f7a86e5772d4d"
+        "fingerprint": "334bbee14583a3c70de5803e481f63d9"
     },
     {
         "severity": "critical",
@@ -221,7 +235,7 @@
                 }
             }
         },
-        "fingerprint": "3728f98d4ad581db5d6d5de043d80b04"
+        "fingerprint": "4707452de6d95f470d3f7a86e5772d4d"
     },
     {
         "severity": "critical",
@@ -263,7 +277,7 @@
                 }
             }
         },
-        "fingerprint": "bf71042969e7b96fa1b21079f8c31395"
+        "fingerprint": "3728f98d4ad581db5d6d5de043d80b04"
     },
     {
         "severity": "critical",
@@ -277,7 +291,7 @@
                 }
             }
         },
-        "fingerprint": "f45770faf0e5cc8220489d6cc2e62737"
+        "fingerprint": "bf71042969e7b96fa1b21079f8c31395"
     },
     {
         "severity": "critical",
@@ -291,7 +305,7 @@
                 }
             }
         },
-        "fingerprint": "78440805017f37372cdbb0851c3cfcca"
+        "fingerprint": "f45770faf0e5cc8220489d6cc2e62737"
     },
     {
         "severity": "critical",
@@ -305,7 +319,7 @@
                 }
             }
         },
-        "fingerprint": "f8a86a99fc1adba9fbb07c8e9b68b79c"
+        "fingerprint": "78440805017f37372cdbb0851c3cfcca"
     },
     {
         "severity": "critical",
@@ -319,7 +333,7 @@
                 }
             }
         },
-        "fingerprint": "0d97a1d886982edd59bbf7f10fbdfc24"
+        "fingerprint": "f8a86a99fc1adba9fbb07c8e9b68b79c"
     },
     {
         "severity": "critical",
@@ -333,7 +347,7 @@
                 }
             }
         },
-        "fingerprint": "bdf2511fe1597205c379b5af82713cfe"
+        "fingerprint": "0d97a1d886982edd59bbf7f10fbdfc24"
     },
     {
         "severity": "critical",
@@ -347,7 +361,7 @@
                 }
             }
         },
-        "fingerprint": "0fa76bb815a6fa3aca64f5c48f699103"
+        "fingerprint": "bdf2511fe1597205c379b5af82713cfe"
     },
     {
         "severity": "critical",
@@ -361,7 +375,7 @@
                 }
             }
         },
-        "fingerprint": "c131d8c8bc6290127971feaf7c7a03f9"
+        "fingerprint": "0fa76bb815a6fa3aca64f5c48f699103"
     },
     {
         "severity": "critical",
@@ -375,7 +389,7 @@
                 }
             }
         },
-        "fingerprint": "6bcccdbb84dc9494e37fb5382e762930"
+        "fingerprint": "c131d8c8bc6290127971feaf7c7a03f9"
     },
     {
         "severity": "critical",
@@ -389,7 +403,7 @@
                 }
             }
         },
-        "fingerprint": "08b5bcd24716127672b423948d246a79"
+        "fingerprint": "6bcccdbb84dc9494e37fb5382e762930"
     },
     {
         "severity": "critical",
@@ -431,7 +445,7 @@
                 }
             }
         },
-        "fingerprint": "fa06c8cb83debf6f41dc568a617e4ae8"
+        "fingerprint": "08b5bcd24716127672b423948d246a79"
     },
     {
         "severity": "critical",
@@ -445,7 +459,7 @@
                 }
             }
         },
-        "fingerprint": "386412d3fb3ece2810a7655018ff71e3"
+        "fingerprint": "fa06c8cb83debf6f41dc568a617e4ae8"
     },
     {
         "severity": "critical",
@@ -459,7 +473,7 @@
                 }
             }
         },
-        "fingerprint": "1ed1653dac0abc0c883375f93094ee07"
+        "fingerprint": "386412d3fb3ece2810a7655018ff71e3"
     },
     {
         "severity": "critical",
@@ -473,7 +487,7 @@
                 }
             }
         },
-        "fingerprint": "863ae8436f16a7b38f8ff128896e19c6"
+        "fingerprint": "1ed1653dac0abc0c883375f93094ee07"
     },
     {
         "severity": "critical",
@@ -515,7 +529,7 @@
                 }
             }
         },
-        "fingerprint": "f0b880a4decc5b519824b56f25ccab4c"
+        "fingerprint": "863ae8436f16a7b38f8ff128896e19c6"
     },
     {
         "severity": "critical",
@@ -543,7 +557,7 @@
                 }
             }
         },
-        "fingerprint": "bf3332c2a47e7445664e8eed086e562e"
+        "fingerprint": "f0b880a4decc5b519824b56f25ccab4c"
     },
     {
         "severity": "critical",
@@ -557,7 +571,7 @@
                 }
             }
         },
-        "fingerprint": "d5420278d788d3fe6507be1eebc26bea"
+        "fingerprint": "bf3332c2a47e7445664e8eed086e562e"
     },
     {
         "severity": "critical",
@@ -571,7 +585,7 @@
                 }
             }
         },
-        "fingerprint": "97b4a6b5258d0c30af08487c94866119"
+        "fingerprint": "d5420278d788d3fe6507be1eebc26bea"
     },
     {
         "severity": "critical",
@@ -599,7 +613,7 @@
                 }
             }
         },
-        "fingerprint": "196d016ae2b75535590d8b895341b667"
+        "fingerprint": "97b4a6b5258d0c30af08487c94866119"
     },
     {
         "severity": "critical",
@@ -613,6 +627,20 @@
                 }
             }
         },
-        "fingerprint": "874cc7f5ff95f687143afdff125fe2f8"
+        "fingerprint": "196d016ae2b75535590d8b895341b667"
+    },
+    {
+        "severity": "major",
+        "description": "12345 Defect: Sign change integer conversion overflow",
+        "location": {
+            "path": "extern",
+            "positions": {
+                "begin": {
+                    "line": 24,
+                    "column": 11
+                }
+            }
+        },
+        "fingerprint": "d147291a6db29707dfb29bae0d7ba159"
     }
 ]


### PR DESCRIPTION
Issue
=====

Polyspace uses `/?extern` for example as file in some cases.
This results in a ValueError when creating code quality reports, which is not intended.

```
ValueError: Failed to convert abolute path to relative path for Code Quality report: '/?extern' is not in the subpath of '/some/other/path' OR one path is relative and the other is absolute.
```

Fix
===

When the path of the file starts with `/?` it will strip these characters and the rest of the text will be the path of that specific finding in the code quality report.

Example: `/?extern` will result in `extern`