### PR TITLE
Traverse nested Robot test suites.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contribution Guide
 Anyone is more than welcome to contribute to the development of warnings-plugin,
 no matter your programming skill level. It is the reviewer's obligation to help bring your
 contribution to our desired quality level and you should do your best to help the reviewer
-understand your decisions. Standard GitHub flow is used https://guides.github.com/introduction/flow/
+understand your decisions. Standard GitHub flow is used https://docs.github.com/en/get-started/using-github/github-flow
 to start Pull Requests, which are then merged. We also prefer to make a Work In Progress
 Merge request once you starting your work just in case someone else is not working on the
 same issue.

--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,9 @@
     :target: https://app.codecov.io/gh/melexis/warnings-plugin
     :alt: Code Coverage
 
-.. image:: https://codeclimate.com/github/melexis/warnings-plugin/badges/gpa.svg
-    :target: https://codeclimate.com/github/melexis/warnings-plugin
-    :alt: Code Climate Status
-
-.. image:: https://codeclimate.com/github/melexis/warnings-plugin/badges/issue_count.svg
-    :target: https://codeclimate.com/github/melexis/warnings-plugin/issues
-    :alt: Issue Count
+.. image:: https://qlty.sh/badges/5b71accf-201e-4281-b6fe-8a5f4893fdbc/maintainability.svg
+    :target: https://qlty.sh/gh/melexis/projects/warnings-plugin
+    :alt: Maintainability
 
 .. image:: https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat
     :target: https://github.com/melexis/warnings-plugin/issues
@@ -620,7 +616,7 @@ development of the plugin. We encourage anyone to contribute to our repository.
 
 .. |string.Template| replace:: ``string.Template``
 .. _YAML: https://yaml.org/spec/1.2.2/
-.. _a Code Quality report: https://docs.gitlab.com/ee/ci/testing/code_quality.html
+.. _a Code Quality report: https://docs.gitlab.com/ci/testing/code_quality/
 .. _the Code Climate spec: https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
-.. _as a codequality report artifact: https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscodequality
+.. _as a codequality report artifact: https://docs.gitlab.com/ci/yaml/artifacts_reports/
 .. _string.Template: https://docs.python.org/3/library/string.html#string.Template.template

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,12 @@ napoleon_use_rtype = False
 napoleon_use_param = False
 
 linkcheck_ignore = [r'https://www\.mathworks\.com.+']
+linkcheck_allowed_redirects = {
+    # All HTTP redirections from the source URI to
+    # the canonical URI will be treated as "working".
+    r'https://www.bestpractices.dev/projects/\d+': r'https://www.bestpractices.dev/\w+/projects/\d+',
+    'https://badge.fury.io/py/mlx.warnings.svg': r'https://\w+.cloudfront.net/badge.svg.+',
+}
 
 # Point to plantuml jar file
 # confirm we have plantuml in the path

--- a/tests/test_in/robot_double_nested_suite.xml
+++ b/tests/test_in/robot_double_nested_suite.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Root Suite" tests="6" errors="0" failures="2" skipped="0" time="0.049">
+<testsuite name="Nested Suite" tests="6" errors="0" failures="2" skipped="0" time="0.049">
+<testsuite name="Double Nested Suite" tests="6" errors="0" failures="2" skipped="0" time="0.049">
+<testsuite name="Suite One" tests="3" errors="0" failures="1" skipped="0" time="0.049">
+    <testcase classname="Root Suite.Nested Suite.Double Nested Suite.Suite One" name="First Test" time="0.002">
+        <failure message="Directory 'C:\nonexistent' does not exist." type="AssertionError"></failure>
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Double Nested Suite.Suite One" name="An Unlinked Test" time="0.002">
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Double Nested Suite.Suite One" name="Another test" time="0.002">
+    </testcase>
+</testsuite>
+<testsuite name="Suite Two" tests="3" errors="0" failures="1" skipped="0" time="0.049">
+    <testcase classname="Root Suite.Nested Suite.Double Nested Suite.Suite Two" name="First Test" time="0.002">
+        <failure message="Directory 'C:\nonexistent' does not exist." type="AssertionError"></failure>
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Double Nested Suite.Suite Two" name="An Unlinked Test" time="0.002">
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Double Nested Suite.Suite Two" name="Another test" time="0.002">
+    </testcase>
+</testsuite>
+</testsuite>
+</testsuite>
+</testsuite>

--- a/tests/test_in/robot_nested_suite.xml
+++ b/tests/test_in/robot_nested_suite.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Root Suite" tests="6" errors="0" failures="2" skipped="0" time="0.049">
+<testsuite name="Nested Suite" tests="6" errors="0" failures="2" skipped="0" time="0.049">
+<testsuite name="Suite One" tests="3" errors="0" failures="1" skipped="0" time="0.049">
+    <testcase classname="Root Suite.Nested Suite.Suite One" name="First Test" time="0.002">
+        <failure message="Directory 'C:\nonexistent' does not exist." type="AssertionError"></failure>
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Suite One" name="An Unlinked Test" time="0.002">
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Suite One" name="Another test" time="0.002">
+    </testcase>
+</testsuite>
+<testsuite name="Suite Two" tests="3" errors="0" failures="1" skipped="0" time="0.049">
+    <testcase classname="Root Suite.Nested Suite.Suite Two" name="First Test" time="0.002">
+        <failure message="Directory 'C:\nonexistent' does not exist." type="AssertionError"></failure>
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Suite Two" name="An Unlinked Test" time="0.002">
+    </testcase>
+    <testcase classname="Root Suite.Nested Suite.Suite Two" name="Another test" time="0.002">
+    </testcase>
+</testsuite>
+</testsuite>
+</testsuite>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -373,6 +373,28 @@ class TestIntegration(TestCase):
             if var in os.environ:
                 del os.environ[var]
 
+    def test_robot_config_nested_suites(self):
+        os.environ["MIN_ROBOT_WARNINGS"] = "0"
+        os.environ["MAX_ROBOT_WARNINGS"] = "0"
+        retval = warnings_wrapper([
+            "--config",
+            "tests/test_in/config_example_robot.json",
+            "tests/test_in/robot_double_nested_suite.xml",
+        ])
+
+        self.assertEqual(
+            ["Robot: suite 'Suite One'    number of warnings (1) is between limits 0 and 1. Well done.",
+             "Robot: all test suites      number of warnings (2) is higher than the maximum limit (1).",
+             "Robot: suite 'Suite Two'    number of warnings (1) is between limits 1 and 2. Well done.",
+             "Robot: suite 'b4d su1te name' number of warnings (0) is exactly as expected. Well done.",
+             "Robot: Returning error code 2."],
+            self.stderr_lines
+        )
+        self.assertEqual(2, retval)
+        for var in ("MIN_ROBOT_WARNINGS", "MAX_ROBOT_WARNINGS"):
+            if var in os.environ:
+                del os.environ[var]
+
     def test_robot_config_check_names(self):
         self.maxDiff = None
         with self.assertRaises(SystemExit) as cm_err:

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -36,6 +36,30 @@ class TestRobotWarnings(unittest.TestCase):
             ],
             self.caplog.messages)
 
+    def test_nested_suite(self):
+        with open("tests/test_in/robot_nested_suite.xml") as xmlfile:
+            self.warnings.check(xmlfile.read())
+            count = self.warnings.return_count()
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            [
+                "Root Suite.Nested Suite.Suite One.First Test",
+                "Root Suite.Nested Suite.Suite Two.First Test"
+            ],
+            self.caplog.messages)
+
+    def test_double_nested_suite(self):
+        with open("tests/test_in/robot_double_nested_suite.xml") as xmlfile:
+            self.warnings.check(xmlfile.read())
+            count = self.warnings.return_count()
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            [
+                "Root Suite.Nested Suite.Double Nested Suite.Suite One.First Test",
+                "Root Suite.Nested Suite.Double Nested Suite.Suite Two.First Test"
+            ],
+            self.caplog.messages)
+
     def test_double_warning_and_verbosity(self):
         retval = warnings_wrapper([
             "--verbose",


### PR DESCRIPTION
The Robot Framework XML parser now correctly traverses all nested test suites. The previous implementation only supported up to two levels of nested suites. This change allows the warnings plugin to identify and report failures in test cases that are located within any number of nested suites.

To verify this, some new test cases have been added.