### PR TITLE
Remove ANSI color escape codes from content

### DIFF
--- a/src/mlx/warnings/regex_checker.py
+++ b/src/mlx/warnings/regex_checker.py
@@ -18,6 +18,8 @@ xmlrunner_pattern = re.compile(PYTHON_XMLRUNNER_REGEX)
 COVERITY_WARNING_REGEX = r"(?P<path>[\w\.\\/\- ]+)(:(?P<line>\d+)(:(?P<column>\d+))?)?: ?CID (?P<cid>\d+) \(#(?P<curr>\d+) of (?P<max>\d+)\): (?P<checker>.+): (?P<classification>[\w ]+),.+"
 coverity_pattern = re.compile(COVERITY_WARNING_REGEX)
 
+ANSI_ESCAPE_REGEX = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
 
 class RegexChecker(WarningsChecker):
     name = "regex"
@@ -39,7 +41,8 @@ class RegexChecker(WarningsChecker):
         Args:
             content (str): The content to parse
         """
-        matches = re.finditer(self.pattern, content)
+        clean_content = ANSI_ESCAPE_REGEX.sub('', content)
+        matches = re.finditer(self.pattern, clean_content)
         for match in matches:
             match_string = match.group(0).strip()
             if self._is_excluded(match_string):


### PR DESCRIPTION
Sphinx has introduced ANSI color escape codes to the warnings to color them red. As a result, the tool can't match warnings when an ANSI color code is present (without filename).

To fix this issue, every ANSI color escape code is removed from the content.